### PR TITLE
Add support for gltf_enumNames

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -263,11 +263,19 @@ function getEnumString(schema, type) {
     if (!defined(propertyEnum)) {
         return undefined;
     }
+    
+    var propertyEnumNames = schema['gltf_enumNames'];
 
     var allowedValues = '';
     var length = propertyEnum.length;
     for (var i = 0; i < length; ++i) {
-        allowedValues += styleEnumElement(propertyEnum[i], type);
+        var element = propertyEnum[i];
+        if (defined(propertyEnumNames))
+        {
+            element += " (" + propertyEnumNames[i] + ")";
+        }
+        
+        allowedValues += styleEnumElement(element, type);
         if (i !== length - 1) {
             allowedValues += ', ';
         }


### PR DESCRIPTION
The result looks something like this
### primitive.mode

The type of primitives to render. All valid values correspond to WebGL
enums.

* **Type**: `integer`
* **Required**: No, default: `4`
* **Allowed values**: `0 (POINTS)`, `1 (LINES)`, `2 (LINE_LOOP)`, `3
(LINE_STRIP)`, `4 (TRIANGLES)`, `5 (TRIANGLE_STRIP)`, `6 (TRIANGLE_FAN)`