### PR TITLE
Add support for json-schema-04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/node_modules
 .DS_Store
 Thumbs.db
+.vscode/*

--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -2,14 +2,16 @@
 "use strict";
 var fs = require('fs');
 var path = require('path');
-var argv = require('minimist')(process.argv.slice(2));
+var argv = require('minimist')(process.argv.slice(2), { boolean : ["w", "suppresswarnings" ]});
 var defined = require('../lib/defined');
 var defaultValue = require('../lib/defaultValue');
 var generateMarkdown = require('../');
 
 if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
     var help = 'Usage: node ' + path.basename(__filename) + ' [path-to-json-schema-file] [OPTIONS]\n' +
-               '  -l, --headerLevel      Top-level header. Default: 1';
+        '  -l,  --headerLevel        Top-level header. Default: 1\n' +
+        '  -d,  --debug              Provide a path, and this will save out intermediate processing artifacts useful in debugging wetzel.' +
+        '  -w,  --suppressWarnings   Will not print out WETZEL_WARNING strings indicating identified conversion problems. Default: false';
     process.stdout.write(help);
     return;
 }
@@ -18,7 +20,10 @@ var filename = argv._[0];
 var schema = JSON.parse(fs.readFileSync(filename));
 
 process.stdout.write(generateMarkdown({
-    schema : schema,
-    basePath : path.dirname(filename),
-    headerLevel : defaultValue(defaultValue(argv.l, argv.headerLevel), 1)
+    schema: schema,
+    filePath: filename,
+    basePath: path.dirname(filename),
+    headerLevel: defaultValue(defaultValue(argv.l, argv.headerLevel), 1),
+    debug: defaultValue(defaultValue(argv.d, argv.debug), null),
+    suppressWarnings: defaultValue(defaultValue(argv.w, argv.suppressWarnings), false),
 }));

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -3,6 +3,13 @@ var defaultValue = require('./defaultValue');
 
 module.exports = clone;
 
+/**
+* @function clone
+* Creates a new instance of the specified object.
+* @param  {object} object - The source object to be cloned.
+* @param  {boolean} deep - Indicates if the clone should be recursive to all nested objects.
+* @return {object} A new instance of the specified object.
+*/
 function clone(object, deep) {
     if (object === null || typeof object !== 'object') {
         return object;

--- a/lib/defaultValue.js
+++ b/lib/defaultValue.js
@@ -3,9 +3,18 @@ var defined = require('./defined');
 
 module.exports = defaultValue;
 
-function defaultValue(a, b) {
-    if (defined(a)) {
-        return a;
+/**
+* @function defaultValue
+* Gets the value of an object, using a fallback default value if the primary
+* value is not defined.
+* @param  {object} value - The value to be returned, assuming it's defined.
+* @param  {object} fallback - The fallback value if value is undefined
+* @return {object} value if it was defined, otherwise fallback.
+*/
+function defaultValue(value, fallback) {
+    if (defined(value)) {
+        return value;
     }
-    return b;
+
+    return fallback;
 }

--- a/lib/defined.js
+++ b/lib/defined.js
@@ -2,6 +2,12 @@
 
 module.exports = defined;
 
+/**
+* @function defined
+* Determines if the specified value exists and is not null.
+* @param  {object} value - The object to check.
+* @return {boolean} true if value exists and is not null; false otherwise
+*/
 function defined(value) {
     return (value !== undefined) && (value !== null);
 }

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -4,33 +4,45 @@ var path = require('path');
 var defined = require('./defined');
 var defaultValue = require('./defaultValue');
 var clone = require('./clone');
+var style = require('./style');
+var schema3 = require('./schema3Resolver');
+var schema4 = require('./schema4Resolver');
 
 module.exports = generateMarkdown;
 
+/**
+* @function generateMarkdown
+* Generates the markdown content to represent the json schema provided within the options parameter.
+* @param  {object} options - The set of configuration options to be fed into the generator.
+* @return {string} The full markdown content based on the requested options.
+*/
 function generateMarkdown(options) {
-    var schema = options.schema;
-    var basePath = defaultValue(options.basePath, '');
-    var headerLevel = defaultValue(options.headerLevel, 1);
     var md = '';
-    var value;
-
-    schema = replaceRef(basePath, schema);
-    extend(schema);
+    var schema = options.schema;
+    options.basePath = defaultValue(options.basePath, '');
 
     // Verify JSON Schema version
-    value = schema.$schema;
-    if (defined(value)) {
-        if (value !== 'http://json-schema.org/draft-03/schema') {
-            md += 'WETZEL_WARNING: only JSON Schema 3 is supported.\n\n';
+    var schemaRef = schema.$schema;
+    if (defined(schemaRef)) {
+        if (schemaRef === 'http://json-schema.org/draft-03/schema') {
+            schema = schema3.resolve(schema, options.basePath, options.debug);
+        }
+        else if (schemaRef === 'http://json-schema.org/draft-04/schema') {
+            schema = schema4.resolve(schema, options.basePath, options.debug);
+        }
+        else
+        {
+            schema = schema3.resolve(schema, options.basePath, options.debug);
+            md += '> WETZEL_WARNING: Only JSON Schema 3 or 4 is supported. Treating as Schema 3.\n\n';
         }
     }
 
     // Render title
-    var title = defaultValue(schema.title, 'WETZEL_WARNING: title not defined');
-    md += getHeaderMarkdown(headerLevel) + ' ' + title + '\n\n';
+    var title = defaultValue(schema.title, options.suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
+    md += style.getHeaderMarkdown(options.headerLevel) + ' ' + title + '\n\n';
 
     // Render description
-    value = schema.description;
+    var value = schema.description;
     if (defined(value)) {
         md += value + '\n\n';
     }
@@ -38,19 +50,19 @@ function generateMarkdown(options) {
     // Render type
     var schemaType = schema.type;
     if (defined(schemaType)) {
-//      md += styleType('Type') + ': ' + styleTypeValue(schemaType) + '\n\n';
+        //      md += styleType('Type') + ': ' + style.typeValue(schemaType) + '\n\n';
     }
 
     // TODO: Add plugin point for custom JSON schema properties like gltf_*
     var webgl = schema.gltf_webgl;
     if (defined(webgl)) {
-        md += stylePropertyGltfWebGL('Related WebGL functions') + ': ' + webgl + '\n\n';
+        md += style.propertyGltfWebGL('Related WebGL functions') + ': ' + webgl + '\n\n';
     }
 
     // Render each property if the type is object
     if (schemaType === 'object') {
         // Render table with summary of each property
-        md += createPropertiesSummary(schema);
+        md += createPropertiesSummary(schema, options.suppressWarnings);
 
         value = schema.additionalProperties;
         if (defined(value) && !value) {
@@ -61,7 +73,7 @@ function generateMarkdown(options) {
         }
 
         // Render section for each property
-        md += createPropertiesDetails(schema, title, headerLevel + 1);
+        md += createPropertiesDetails(schema, title, options.headerLevel + 1, options.suppressWarnings);
     }
 
     return md;
@@ -69,9 +81,9 @@ function generateMarkdown(options) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-function createPropertiesSummary(schema) {
+function createPropertiesSummary(schema, suppressWarnings) {
     var md = '';
-    md += stylePropertiesSummary('Properties') + '\n\n';
+    md += style.propertiesSummary('Properties') + '\n\n';
     md += '|   |Type|Description|Required|\n';
     md += '|---|----|-----------|--------|\n';
 
@@ -79,12 +91,12 @@ function createPropertiesSummary(schema) {
     for (var name in properties) {
         if (properties.hasOwnProperty(name)) {
             var property = properties[name];
-            var summary = getPropertySummary(property);
+            var summary = getPropertySummary(property, suppressWarnings);
 
-            md += '|' + stylePropertyNameSummary(name) +
-                  '|' + styleTypeValue(summary.type) +
-                  '|' + defaultValue(summary.description, '') +
-                  '|' + (summary.required === 'Yes' ? requiredIcon : '') + summary.required + '|\n';
+            md += '|' + style.propertyNameSummary(name) +
+                '|' + style.typeValue(summary.type) +
+                '|' + defaultValue(summary.description, '') +
+                '|' + (summary.required === 'Yes' ? style.requiredIcon : '') + summary.required + '|\n';
         }
     }
     md += '\n';
@@ -92,8 +104,8 @@ function createPropertiesSummary(schema) {
     return md;
 }
 
-function createPropertiesDetails(schema, title, headerLevel) {
-    var headerMd = getHeaderMarkdown(headerLevel);
+function createPropertiesDetails(schema, title, headerLevel, suppressWarnings) {
+    var headerMd = style.getHeaderMarkdown(headerLevel);
     var md = '';
 
     var properties = schema.properties;
@@ -101,9 +113,9 @@ function createPropertiesDetails(schema, title, headerLevel) {
         if (properties.hasOwnProperty(name)) {
             var property = properties[name];
             var type = property.type;
-            var summary = getPropertySummary(property);
+            var summary = getPropertySummary(property, suppressWarnings);
 
-            md += headerMd + ' ' + title + '.' + name + (summary.required === 'Yes' ? requiredIcon : '') + '\n\n';
+            md += headerMd + ' ' + title + '.' + name + (summary.required === 'Yes' ? style.requiredIcon : '') + '\n\n';
 
             // TODO: Add plugin point for custom JSON schema properties like gltf_*
             var detailedDescription = property.gltf_detailedDescription;
@@ -113,11 +125,11 @@ function createPropertiesDetails(schema, title, headerLevel) {
                 md += summary.description + '\n\n';
             }
 
-            md += '* ' + stylePropertyDetails('Type') + ': ' + styleTypeValue(summary.type) + '\n';
+            md += '* ' + style.propertyDetails('Type') + ': ' + style.typeValue(summary.type) + '\n';
 
             var uniqueItems = property.uniqueItems;
             if (defined(uniqueItems) && uniqueItems) {
-            	md += '   * Each element in the array must be unique.\n';
+                md += '   * Each element in the array must be unique.\n';
             }
 
             // TODO: items is a full schema
@@ -130,19 +142,19 @@ function createPropertiesDetails(schema, title, headerLevel) {
                 var maxString = itemsExclusiveMaximum ? 'less than' : 'less than or equal to';
 
                 if (defined(items.minimum) && defined(items.maximum)) {
-                    md += '   * Each element in the array must be ' + minString + ' ' + styleMinMax(items.minimum) + ' and ' + maxString + ' ' + styleMinMax(items.maximum) + '.\n';
+                    md += '   * Each element in the array must be ' + minString + ' ' + style.minMax(items.minimum) + ' and ' + maxString + ' ' + style.minMax(items.maximum) + '.\n';
                 } else if (defined(items.minimum)) {
-                    md += '   * Each element in the array must be ' + minString + ' ' + styleMinMax(items.minimum) + '.\n';
+                    md += '   * Each element in the array must be ' + minString + ' ' + style.minMax(items.minimum) + '.\n';
                 } else if (defined(items.maximum)) {
-                    md += '   * Each element in the array must be ' + maxString + ' ' + styleMinMax(items.maximum) + '.\n';
+                    md += '   * Each element in the array must be ' + maxString + ' ' + style.minMax(items.maximum) + '.\n';
                 }
 
                 if (defined(items.minLength) && defined(items.maxLength)) {
-                    md += '   * Each element in the array must have length between ' + styleMinMax(items.minLength) + ' and ' + styleMinMax(items.maxLength) + '.\n';
+                    md += '   * Each element in the array must have length between ' + style.minMax(items.minLength) + ' and ' + style.minMax(items.maxLength) + '.\n';
                 } else if (defined(items.minLength)) {
-                    md += '   * Each element in the array must have length greater than or equal to ' + styleMinMax(items.minLength) + '.\n';
+                    md += '   * Each element in the array must have length greater than or equal to ' + style.minMax(items.minLength) + '.\n';
                 } else if (defined(items.maxLength)) {
-                    md += '   * Each element in the array must have length less than or equal to ' + styleMinMax(items.maxLength) + '.\n';
+                    md += '   * Each element in the array must have length less than or equal to ' + style.minMax(items.maxLength) + '.\n';
                 }
 
                 var itemsString = getEnumString(items, type);
@@ -151,48 +163,48 @@ function createPropertiesDetails(schema, title, headerLevel) {
                 }
             }
 
-            md += '* ' + stylePropertyDetails('Required') + ': ' + summary.required + '\n';
+            md += '* ' + style.propertyDetails('Required') + ': ' + summary.required + '\n';
 
             var minimum = property.minimum;
             if (defined(minimum)) {
                 var exclusiveMinimum = (defined(property.exclusiveMinimum) && property.exclusiveMinimum);
-                md += '* ' + stylePropertyDetails('Minimum') + ':' + styleMinMax((exclusiveMinimum ? ' > ' : ' >= ') + minimum) + '\n';
+                md += '* ' + style.propertyDetails('Minimum') + ': ' + style.minMax((exclusiveMinimum ? ' > ' : ' >= ') + minimum) + '\n';
             }
 
             var maximum = property.maximum;
             if (defined(maximum)) {
                 var exclusiveMaximum = (defined(property.exclusiveMaximum) && property.exclusiveMaximum);
-                md += '* ' + stylePropertyDetails('Maximum') + ':' + styleMinMax((exclusiveMaximum ? ' < ' : ' <= ') + maximum) + '\n';
+                md += '* ' + style.propertyDetails('Maximum') + ': ' + style.minMax((exclusiveMaximum ? ' < ' : ' <= ') + maximum) + '\n';
             }
 
             var format = property.format;
             if (defined(format)) {
-                md += '* ' + stylePropertyDetails('Format') + ': ' + format + '\n';
+                md += '* ' + style.propertyDetails('Format') + ': ' + format + '\n';
             }
 
             // TODO: maxLength
             var minLength = property.minLength;
             if (defined(minLength)) {
-                md += '* ' + stylePropertyDetails('Minimum Length') + styleMinMax(': >= ' + minLength) + '\n';
+                md += '* ' + style.propertyDetails('Minimum Length') + style.minMax(': >= ' + minLength) + '\n';
             }
 
             var enumString = getEnumString(property, type);
             if (defined(enumString)) {
-                md += '* ' + stylePropertyDetails('Allowed values') + ': ' + enumString + '\n';
+                md += '* ' + style.propertyDetails('Allowed values') + ': ' + enumString + '\n';
             }
 
-	        var additionalProperties = property.additionalProperties;
-	        if (defined(additionalProperties) && (typeof additionalProperties === 'object')) {
+            var additionalProperties = property.additionalProperties;
+            if (defined(additionalProperties) && (typeof additionalProperties === 'object')) {
                 if (defined(additionalProperties.type)) {
                     // TODO: additionalProperties is really a full schema
-                    md += '* ' + stylePropertyDetails('Type of each property') + ': ' + styleTypeValue(additionalProperties.type) + '\n';
+                    md += '* ' + style.propertyDetails('Type of each property') + ': ' + style.typeValue(additionalProperties.type) + '\n';
                 }
             }
 
             // TODO: Add plugin point for custom JSON schema properties like gltf_*
             var webgl = property.gltf_webgl;
             if (defined(webgl)) {
-                md += '* ' + stylePropertyGltfWebGL('Related WebGL functions') + ': ' + webgl + '\n';
+                md += '* ' + style.propertyGltfWebGL('Related WebGL functions') + ': ' + webgl + '\n';
             }
 
             md += '\n';
@@ -203,8 +215,8 @@ function createPropertiesDetails(schema, title, headerLevel) {
     return md;
 }
 
-function getPropertySummary(property) {
-    var type = defaultValue(property.type, 'WETZEL_WARNING: type not defined');
+function getPropertySummary(property, suppressWarnings) {
+    var type = defaultValue(property.type, suppressWarnings ? '' : 'WETZEL_WARNING: type not defined');
     if (type === 'array') {
         var insideBrackets = '';
         if ((defined(property.minItems)) && (property.minItems === property.maxItems)) {
@@ -236,25 +248,25 @@ function getPropertySummary(property) {
     } else {
         var propertyDefault = property.default;
         if (defined(propertyDefault)) {
-        	var defaultString;
-        	if (Array.isArray(propertyDefault)) {
+            var defaultString;
+            if (Array.isArray(propertyDefault)) {
                 defaultString = '[' + propertyDefault.toString() + ']';
             } else if (typeof propertyDefault === 'object') {
                 defaultString = JSON.stringify(propertyDefault);
-        	} else {
+            } else {
                 defaultString = propertyDefault;
-        	}
+            }
 
-            required = 'No, default: ' + styleDefaultValue(defaultString, type);
+            required = 'No, default: ' + style.defaultValue(defaultString, type);
         } else {
             required = 'No';
         }
     }
 
     return {
-        type : type,
-        description : description,
-        required : required
+        type: type,
+        description: description,
+        required: required
     };
 }
 
@@ -263,130 +275,21 @@ function getEnumString(schema, type) {
     if (!defined(propertyEnum)) {
         return undefined;
     }
-    
+
     var propertyEnumNames = schema['gltf_enumNames'];
 
     var allowedValues = '';
     var length = propertyEnum.length;
     for (var i = 0; i < length; ++i) {
         var element = propertyEnum[i];
-        if (defined(propertyEnumNames))
-        {
+        if (defined(propertyEnumNames)) {
             element += " (" + propertyEnumNames[i] + ")";
         }
-        
-        allowedValues += styleEnumElement(element, type);
+
+        allowedValues += style.enumElement(element, type);
         if (i !== length - 1) {
             allowedValues += ', ';
         }
     }
     return allowedValues;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Styles
-
-function getHeaderMarkdown(level) {
-    var md = '';
-    for (var i = 0; i < level; ++i) {
-        md += '#';
-    }
-
-    return md;
-}
-
-function styleBold(string) {
-    return '**' + string + '**';
-}
-
-function styleCode(string) {
-    return '`' + string + '`';
-}
-
-function styleCodeType(string, type) {
-    if (type === 'string') {
-        return '`"' + string + '"`';
-    }
-
-    return '`' + string + '`';
-}
-
-var styleType = styleBold;
-var styleTypeValue = styleCode;
-var stylePropertiesSummary = styleBold;
-var stylePropertyNameSummary = styleBold;
-var stylePropertiesDetails = styleBold;
-var stylePropertyDetails = styleBold;
-var stylePropertyGltfWebGL = styleBold;
-var styleDefaultValue = styleCodeType;
-var styleEnumElement = styleCodeType;
-var styleMinMax = styleCode;
-
-var requiredIcon = ' :white_check_mark: ';
-
-////////////////////////////////////////////////////////////////////////////////
-
-function replaceRef(basePath, schema) {
-    var ref = schema.$ref;
-    if (defined(ref)) {
-        // TODO: $ref could also be absolute.
-        var filename = path.join(basePath, ref);
-        var refSchema = JSON.parse(fs.readFileSync(filename));
-        return replaceRef(basePath, refSchema);
-    }
-
-    for (var name in schema) {
-        if (schema.hasOwnProperty(name)) {
-            if (typeof schema[name] === 'object') {
-                schema[name] = replaceRef(basePath, schema[name]);
-            }
-        }
-    }
-
-    return schema;
-}
-
-function extend(derived) {
-    var base = derived['extends'];
-    if (defined(base)) {
-        delete derived['extends'];
-        // TODO: extends could be an array
-        mergeProperties(derived, base);
-
-        extend(derived);
-    }
-
-    for (var name in derived) {
-        if (derived.hasOwnProperty(name)) {
-            if (typeof derived[name] === 'object') {
-                extend(derived[name]);
-            }
-        }
-    }
-}
-
-function mergeProperties(derived, base) {
-    for (var name in base) {
-        if (base.hasOwnProperty(name)) {
-            var baseProperty = base[name];
-
-            // Inherit from the base schema.  The derived schema overrides if it has the same property.
-            if (typeof baseProperty === 'object') {
-                derived[name] = defaultValue(derived[name], {});
-                var derivedProperty = derived[name];
-
-                for (var n in baseProperty) {
-                    if (baseProperty.hasOwnProperty(n)) {
-                        if (!defined(derivedProperty[n])) {
-                            derivedProperty[n] = clone(baseProperty[n], true);
-                        }
-                    }
-                }
-            } else {
-                if (!defined(derived[name])) {
-                    derived[name] = clone(baseProperty, true);
-                }
-            }
-        }
-    }
 }

--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -1,0 +1,35 @@
+"use strict";
+var defined = require('./defined');
+var path = require('path');
+var fs = require('fs');
+
+module.exports = replaceRef;
+
+/**
+* @function replaceRef
+* Replaces json schema file references referenced with a $ref property
+* with the actual file content from the referenced schema file.
+* @todo Does not currently support absolute reference paths, only relative paths.
+* @param  {object} schema - The parsed json schema file as an object
+* @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @return {object} The schema object with all schema file referenced replaced with the actual file content.
+*/
+function replaceRef(schema, basePath) {
+    var ref = schema.$ref;
+    if (defined(ref)) {
+        // TODO: $ref could also be absolute.
+        var filename = path.join(basePath, ref);
+        var refSchema = JSON.parse(fs.readFileSync(filename));
+        return replaceRef(refSchema, basePath);
+    }
+
+    for (var name in schema) {
+        if (schema.hasOwnProperty(name)) {
+            if (typeof schema[name] === 'object') {
+                schema[name] = replaceRef(schema[name], basePath);
+            }
+        }
+    }
+
+    return schema;
+}

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -1,0 +1,106 @@
+"use strict";
+var fs = require('fs');
+var path = require('path');
+var defined = require('./defined');
+var defaultValue = require('./defaultValue');
+var clone = require('./clone');
+var replaceRef = require('./replaceRef');
+
+module.exports = { resolve: resolve };
+
+/**
+* @function resolve
+* Normalizes the json-schema-03 object provided for use with wetzel markdown generation,
+* by replacing json schema references ($ref) with the actual content, and then merging
+* in the properties as-needed.
+* @param  {object} schema - The parsed json schema file as an object
+* @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
+* @return {object} The resolved schema object
+*/
+function resolve(schema, basePath, debugOutputPath) {
+    if (null !== debugOutputPath) {
+        fs.writeFileSync(debugOutputPath + ".original.json", JSON.stringify(schema), function (err) {
+            if (err) { console.log(err); }
+        });
+    }
+
+    schema = replaceRef(schema, basePath);
+    if (null !== debugOutputPath) {
+        fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schema), function (err) {
+            if (err) { console.log(err); }
+        });
+    }
+    
+    extend(schema);
+    if (null !== debugOutputPath) {
+        fs.writeFileSync(debugOutputPath + ".schema3.resolved.json", JSON.stringify(schema), function (err) {
+            if (err) { console.log(err); }
+        });
+    }
+
+    return schema;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+* @function extend
+* Recursively finds schemas being referenced within the 'extends' property and merges
+* those properties into the referencing part of the schema.
+* @param  {object} derived - The json schema object that may have an 'extends' property that needs resolving.
+* @return {object} The resolved json schema object.
+*/
+function extend(derived) {
+    var base = derived['extends'];
+    if (defined(base)) {
+        delete derived['extends'];
+        // TODO: extends could be an array
+        mergeProperties(derived, base);
+
+        extend(derived);
+    }
+
+    for (var name in derived) {
+        if (derived.hasOwnProperty(name)) {
+            if (typeof derived[name] === 'object') {
+                extend(derived[name]);
+            }
+        }
+    }
+}
+
+/**
+* @function mergeProperties
+* Recusively takes properties within a schema reference ("the base") and merges the contents of
+* those properties into the derived schema.
+* @param  {object} derived - The schema that contains a reference to the 'base' schema.
+* @param  {object} base - The schema that was being referenced by 'derived'.
+* @return {object} The merged schema with the 'base' schema reference removed since the contents
+* have been merged into 'derived'.
+*/
+function mergeProperties(derived, base) {
+    for (var name in base) {
+        if (base.hasOwnProperty(name)) {
+            var baseProperty = base[name];
+
+            // Inherit from the base schema.  The derived schema overrides if it has the same property.
+            if (typeof baseProperty === 'object') {
+                derived[name] = defaultValue(derived[name], {});
+                var derivedProperty = derived[name];
+
+                for (var n in baseProperty) {
+                    if (baseProperty.hasOwnProperty(n)) {
+                        if (!defined(derivedProperty[n])) {
+                            derivedProperty[n] = clone(baseProperty[n], true);
+                        }
+                    }
+                }
+            } else {
+                if (!defined(derived[name])) {
+                    derived[name] = clone(baseProperty, true);
+                }
+            }
+        }
+    }
+}

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -1,0 +1,158 @@
+"use strict";
+var fs = require('fs');
+var path = require('path');
+var defined = require('./defined');
+var defaultValue = require('./defaultValue');
+var clone = require('./clone');
+var replaceRef = require('./replaceRef');
+
+module.exports = { resolve: resolve };
+
+/**
+* @function resolve
+* Normalizes the json-schema-04 object provided for use with wetzel markdown generation,
+* by replacing json schema references ($ref) with the actual content, and then merging
+* in the properties as-needed.
+* @param  {object} schema - The parsed json schema file as an object
+* @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
+* @return {object} The resolved schema object
+*/
+function resolve(schema, basePath, debugOutputPath) {
+    if (null !== debugOutputPath) {
+        fs.writeFileSync(debugOutputPath + ".original.json", JSON.stringify(schema), function (err) {
+            if (err) { console.log(err); }
+        });
+    }
+
+    schema = replaceRef(schema, basePath);
+    if (null !== debugOutputPath) {
+        fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schema), function (err) {
+            if (err) { console.log(err); }
+        });
+    }
+
+    resolveInheritance(schema);
+    if (null !== debugOutputPath) {
+        fs.writeFileSync(debugOutputPath + ".schema4.resolved.json", JSON.stringify(schema), function (err) {
+            if (err) { console.log(err); }
+        });
+    }
+
+    normalizeRequired(schema);
+    if (null !== debugOutputPath) {
+        fs.writeFileSync(debugOutputPath + ".schema4.requiredNormalized.json", JSON.stringify(schema), function (err) {
+            if (err) { console.log(err); }
+        });
+    }
+
+    return schema;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+* @function resolveInheritance
+* Recursively finds schemas being referenced within the 'allOf' properties and merges
+* those properties into the referencing part of the schema.
+* @param  {object} derived - The json schema object that may have an 'allOf' property that needs resolving.
+* @return {object} The resolved json schema object.
+* @todo Consider adding support for 'anyOf' and 'oneOf' as well.  These currently aren't used by glTF.
+*/
+function resolveInheritance(derived) {
+    var base = derived['allOf'];
+    if (defined(base)) {
+        resolveInheritance(base);
+
+        for (var singleBase in base) {
+            mergeProperties(derived, base[singleBase]);
+        }
+
+        delete derived['allOf'];
+    }
+
+    for (var name in derived) {
+        if (derived.hasOwnProperty(name)) {
+            if (typeof derived[name] === 'object') {
+                resolveInheritance(derived[name]);
+            }
+        }
+    }
+}
+
+/**
+* @function mergeProperties
+* Recusively takes properties within a schema reference ("the base") and merges the contents of
+* those properties into the derived schema.
+* @param  {object} derived - The schema that contains a reference to the 'base' schema.
+* @param  {object} base - The schema that was being referenced by 'derived'.
+* @return {object} The merged schema with the 'base' schema reference removed since the contents
+* have been merged into 'derived'.
+*/
+function mergeProperties(derived, base) {
+    for (var name in base) {
+        if (base.hasOwnProperty(name)) {
+            var baseProperty = base[name];
+
+            // Inherit from the base schema.  The derived joins existing values if it has the same property.
+            if (typeof baseProperty === 'object') {
+                if (Array.isArray(baseProperty)) {
+                    derived[name] = defaultValue(derived[name], []);
+                    var cloned = clone(baseProperty, true);
+                    derived[name] = derived[name].concat(cloned);
+                } else {
+                    derived[name] = defaultValue(derived[name], {});
+                    var derivedProperty = derived[name];
+
+                    for (var n in baseProperty) {
+                        var cloned = clone(baseProperty[n], true);
+                        if (baseProperty.hasOwnProperty(n)) {
+                            if (defined(derivedProperty[n])) {
+                                derivedProperty[n] = Object.assign(derivedProperty[n], cloned);
+                            } else {
+                                derivedProperty[n] = cloned;
+                            }
+                        }
+                    }
+                }
+            } else {
+                var cloned = clone(baseProperty, true);
+                if (!defined(derived[name])) {
+                    derived[name] = cloned;
+                }
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+* @function normalizeRequired
+* Schema3 used a bool attribute on an individual property to indicate if it was
+* required or not.  Schema4 uses an array attribute on the parent root that
+* references properties by name that should be considered required.  We'll normalize
+* to bool attributes on the individual properties so that the markdown generation
+* logic can be shared amongst the different schema resolvers.
+* By design, this isn't recursively normalizing the schema.  We only care about
+* the first level within the schema, as we'll re-process the nested schemas
+* separately.
+* @param  {object} schema - The json schema object that needs the 'required' properties to be normalized.
+* @return {object} The normalized json schema object
+*/
+function normalizeRequired(schema) {
+    for (var name in schema.properties) {
+        if (schema.properties.hasOwnProperty(name)){
+            var property = schema.properties[name];
+            if (!defined(property.required) &&
+                defined(schema.required) &&
+                Array.isArray(schema.required) &&
+                schema.required.indexOf(name) >= 0)
+            {
+                property.required = true;
+            }
+        }
+    }
+
+    return schema;
+}

--- a/lib/style.js
+++ b/lib/style.js
@@ -1,0 +1,153 @@
+"use strict";
+var defined = require('./defined');
+
+module.exports = {
+    getHeaderMarkdown: getHeaderMarkdown,
+
+    /**
+    * @function type
+    * Format the type heading for display in markdown
+    * @param  {string} string - The type heading to be styled
+    * @return {string} The type heading styled for display in markdown.
+    */
+    type: styleBold,
+
+    /**
+    * @function typeValue
+    * Format a typeValue for display in markdown
+    * @param  {string} string - The type value to be styled
+    * @return {string} The typeValue styled for display in markdown.
+    */
+    typeValue: styleCode,
+
+    /**
+    * @function propertiesSummary
+    * Format the summary of properties for display in markdown
+    * @param  {string} string - The summary of properties to be styled
+    * @return {string} The summary of properties styled for display in markdown.
+    */
+    propertiesSummary: styleBold,
+
+    /**
+    * @function propertyNameSummary
+    * Format a property name for display in markdown
+    * @param  {string} string - The property name summary to be styled
+    * @return {string} The styled property name summary for display in markdown.
+    */
+    propertyNameSummary: styleBold,
+
+    /**
+    * @function propertiesDetails
+    * Format the details of properties for display in markdown
+    * @param  {string} string - The details of properties to be styled
+    * @return {string} The details of properties styled for display in markdown.
+    */
+    propertiesDetails: styleBold,
+
+    /**
+    * @function propertyDetails
+    * Format the details of a property for display in markdown
+    * @param  {string} string - The property details to be styled
+    * @return {string} The property details styled for display in markdown.
+    */
+    propertyDetails: styleBold,
+
+    /**
+    * @function propertyGltfWebGL
+    * Format a glTF WebGL property for display in markdown
+    * @param  {string} string - The glTF WebGL property to be styled
+    * @return {string} The glTF WebGL property styled for display in markdown.
+    */
+    propertyGltfWebGL: styleBold,
+
+    /**
+    * @function defaultValue
+    * Format a defaultValue for display in markdown
+    * @param  {string} string - The default value
+    * @param  {type} string - The type of the default value
+    * @return {string} The default value styled for display in markdown.
+    */
+    defaultValue: styleCodeType,
+
+    /**
+    * @function enumElement
+    * Format an enumElement for display in markdown
+    * @param  {string} string - The enum element to be styled
+    * @param  {type} string - The type of the enum element
+    * @return {string} The enum element styled for display in markdown.
+    */
+    enumElement: styleCodeType,
+
+    /**
+    * @function minMax
+    * Format a minimum or maximum value for display in markdown
+    * @param  {string} string - The minimum/maximum value to be styled
+    * @return {string} The minimum or maximum value styled for display in markdown.
+    */
+    minMax: styleCode,
+
+    /**
+    * @property {string} The markdown string used for displaying the icon used to indicate a value is required.
+    */
+    requiredIcon: ' :white_check_mark: '
+}
+
+/**
+* @function getHeaderMarkdown
+* Gets the markdown syntax for the start of a header.
+* @param  {int} level - The header lever that is being requested
+* @return {string} The markdown string that should be placed prior to the title of the header
+*/
+function getHeaderMarkdown(level) {
+    var md = '';
+    for (var i = 0; i < level; ++i) {
+        md += '#';
+    }
+
+    return md;
+}
+
+/**
+* @function styleBold
+* Returns back a markdown string that bolds the provided string.
+* @param  {string} string - The string to be bolded
+* @return {string} The bolded string in markdown syntax
+*/
+function styleBold(string) {
+    if (defined(string) && string.length > 0) {
+        return '**' + string + '**';
+    }
+
+    return '';
+}
+
+/**
+* @function styleCode
+* Returns back a markdown string that displays the provided string as code.
+* @param  {string} string - The string to be displayed as code
+* @return {string} The string in markdown code syntax
+*/
+function styleCode(string) {
+    if (defined(string) && string.length > 0) {
+        return '`' + string + '`'
+    }
+
+    return '';
+}
+
+/**
+* @function styleCodeType
+* Returns back a markdown string that displays the provided string as code.
+* @param  {string} string - The string to be displayed as code
+* @param  {string} type - The type of the content in string (if it's a literal string, it will be formatted differently)
+* @return {string} The string in markdown code syntax
+*/
+function styleCodeType(string, type) {
+    if (!defined(string) || string.length === 0) {
+        return '';
+    } else if (type === 'string') {
+        return styleCode('"' + string + '"');
+    }
+
+    return styleCode(string);
+}


### PR DESCRIPTION
The glTF spec has been updated to be based on
[json-schema-04](https://tools.ietf.org/html/draft-fge-json-schema-validation-00)
as opposed to the previous [json-schema-03](https://tools.ietf.org/html/draft-zyp-json-schema-03).

That change rendered wetzel obsolete since it could no longer handle schema references
or "required" validation.

This change updates wetzel to support json-schema-04 and have feature parity with
what it output with the equivalent glTF schema file written using json-schema-03.

> A coming change will further enhance wetzel to understand the different custom
> object types and provide markdown references between those generated types.

In this change, the following has happened:

* Extracted all of the style definitions to a separate `style.js` file and updated all references.
* Updated the markdown generator to choose a schema "resolver" based on the version
   of the schema being used:
   * A set of three functions were previously used to merge all schema references into
     a single schema that could then be used for generating the markdown content:
      * `replaceRef` - replaced json schema references with the actual json content
      * `extend` - identified all the `extend` integration points and merged in the content
        of the referenced schema
      * `mergeProperties` - helper function used in conjunction with `extend`
   * Extracted the `replaceRef` function to its own file (`replaceRef.js`).  Also swapped the order
   of the parameters to better denote the priority of each parameter.
   * Moved `extend` and `mergeProperties` into new file `schema3Resolver.js`
   * Created a new `schema4Resolver.js` that has similar functionality, but will create the same
     end result with files based on schema4.
   * Updated `generateMarkdown.js` to choose the right "resolver" based on schema version.
* A new `-w` / `--suppressWarnings` option has been added that causes wetzel to not print
  out the warnings that it would otherwise normally print out during normal operation,
* A new `-d` / `--debug` option has been added that causes wetzel to spit out intermediate
  artifacts during processing in order to help with the debugging process.
* Updated `.gitignore` to ignore IDE environment files used by
   [Visual Studio Code](https://code.visualstudio.com/).
* Added [JSDoc](http://usejsdoc.org/) documentation for the majority of the code being touched.
  The remainder of the code missing JSDoc documentation will likely get it added in subsequent
  changes.