### PR TITLE
Create interlinked documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Options:
 * The `-p` option lets you specify the relative path that should be used when referencing the schema, relative to where you store the documentation.
 * The `-w` option will suppress any warnings about potential documentation problems that wetzel normally prints by default.
 * The `-d` option lets you specify the root filename that will be used for writing intermediate wetzel artifacts that are useful when doing wetzel development.
+* The `-a` option will attempt to aggressively auto-link referenced type names in descriptions between each other.  If it's too agressive, you can add `=cqo` so that it only attempts to auto-link type names that are within "code-quotes only" (cqo) (e.g.: ``typeName``)
 
 <a name="common-usage"></a>
 ## Common Usage
@@ -102,13 +103,16 @@ The most common way to use this tool is to generate the entire glTF documentatio
 To do that, you simply need to pass-in the root schema file (glTF.schema.json):
 
 ```
-wetzel ../gltf/specification/2.0/schema/glTF.schema.json -p schema/ | clip
+wetzel ../glTF/specification/2.0/schema/gltf.schema.json -l 2 -p schema/ -i "['gltfid.schema.json', 'gltfchildofrootproperty.schema.json', 'gltfproperty.schema.json']" -a | clip
 ```
 
 That will generate documentation for glTF.schema.json, as well as all referenced schemas,
 all in a single set of markdown with inter-type linking.  By specifying the `-p` parameter,
 you've indicated where the actual json schema files will live relative to the documentation
-so that the type documentation can directly link to the type json file.
+so that the type documentation can directly link to the type json file.  By specifying the
+`-i` parameter, you've specified the list of schema files that should be ignored when writing
+out the top-level types.  By specifying the `-a` parameter, it will aggressively attempt to
+auto-link all referenced type names with each other.
 
 <a name="Limitations"></a>
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -81,20 +81,39 @@ It is useful to pipe the Markdown output to the clipboard and then paste into a 
 
 On Mac:
 ```
-wetzel ../glTF/specification/schema/accessor.schema.json -l 2 | pbcopy
+wetzel ../glTF/specification/2.0/schema/accessor.schema.json -l 2 | pbcopy
 ```
 
 On Windows:
 ```
-wetzel ../glTF/specification/schema/accessor.schema.json -l 2 | clip
+wetzel.js ../glTF/specification/2.0/schema/accessor.schema.json -l 2 | clip
 ```
 
-The `-l` option specifies the starting header level.
+Options:
+* The `-l` option specifies the starting header level.
+* The `-p` option lets you specify the relative path that should be used when referencing the schema, relative to where you store the documentation.
+* The `-w` option will suppress any warnings about potential documentation problems that wetzel normally prints by default.
+* The `-d` option lets you specify the root filename that will be used for writing intermediate wetzel artifacts that are useful when doing wetzel development.
+
+<a name="common-usage"></a>
+## Common Usage
+
+The most common way to use this tool is to generate the entire glTF documentation.
+To do that, you simply need to pass-in the root schema file (glTF.schema.json):
+
+```
+wetzel ../gltf/specification/2.0/schema/glTF.schema.json -p schema/ | clip
+```
+
+That will generate documentation for glTF.schema.json, as well as all referenced schemas,
+all in a single set of markdown with inter-type linking.  By specifying the `-p` parameter,
+you've indicated where the actual json schema files will live relative to the documentation
+so that the type documentation can directly link to the type json file.
 
 <a name="Limitations"></a>
 ## Limitations
 
-This tool was developed to generate reference documentaiton for the [glTF](https://github.com/KhronosGroup/glTF) schema.  As such, it currently only supports JSON Schema 3 and doesn't support the entire JSON Schema spec.  However, wetzel is easy to hack on, just edit [lib/generateMarkdown.js](lib/generateMarkdown.js).
+This tool was developed to generate reference documentaiton for the [glTF](https://github.com/KhronosGroup/glTF) schema.  As such, it currently only supports JSON Schema 3 and 4, and doesn't support the entire JSON Schema spec.  However, wetzel is easy to hack on, just edit [lib/generateMarkdown.js](lib/generateMarkdown.js).
 
 ## Contributions
 

--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -10,20 +10,23 @@ var generateMarkdown = require('../');
 if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
     var help = 'Usage: node ' + path.basename(__filename) + ' [path-to-json-schema-file] [OPTIONS]\n' +
         '  -l,  --headerLevel        Top-level header. Default: 1\n' +
+        '  -p,  --schemaPath         The path string that should be used when generating the schema reference paths.\n' +
         '  -d,  --debug              Provide a path, and this will save out intermediate processing artifacts useful in debugging wetzel.' +
         '  -w,  --suppressWarnings   Will not print out WETZEL_WARNING strings indicating identified conversion problems. Default: false';
     process.stdout.write(help);
     return;
 }
 
-var filename = argv._[0];
-var schema = JSON.parse(fs.readFileSync(filename));
+var filepath = argv._[0];
+var schema = JSON.parse(fs.readFileSync(filepath));
 
 process.stdout.write(generateMarkdown({
     schema: schema,
-    filePath: filename,
-    basePath: path.dirname(filename),
+    filePath: filepath,
+    fileName: path.basename(filepath),
+    basePath: path.dirname(filepath),
     headerLevel: defaultValue(defaultValue(argv.l, argv.headerLevel), 1),
+    schemaRelativeBasePath: defaultValue(defaultValue(argv.p, argv.schemaPath), null),
     debug: defaultValue(defaultValue(argv.d, argv.debug), null),
     suppressWarnings: defaultValue(defaultValue(argv.w, argv.suppressWarnings), false),
 }));

--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -12,7 +12,7 @@ if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
     var help = 'Usage: node ' + path.basename(__filename) + ' [path-to-json-schema-file] [OPTIONS]\n' +
         '  -l,  --headerLevel        Top-level header. Default: 1\n' +
         '  -p,  --schemaPath         The path string that should be used when generating the schema reference paths.\n' +
-        '  -al, --autoLink           Aggressively auto-inter-link types referenced in descriptions.  Add =cqo to auto-link types that are in code-quotes only.\n' +
+        '  -a,  --autoLink           Aggressively auto-inter-link types referenced in descriptions.  Add =cqo to auto-link types that are in code-quotes only.\n' +
         '  -d,  --debug              Provide a path, and this will save out intermediate processing artifacts useful in debugging wetzel.' +
         '  -w,  --suppressWarnings   Will not print out WETZEL_WARNING strings indicating identified conversion problems. Default: false';
     process.stdout.write(help);
@@ -23,10 +23,11 @@ var filepath = argv._[0];
 var schema = JSON.parse(fs.readFileSync(filepath));
 
 var autoLink = enums.autoLinkOption.off;
-switch (defaultValue(argv.al, argv.autoLink)) {
+switch (defaultValue(argv.a, argv.autoLink)) {
     case true:
         autoLink = enums.autoLinkOption.aggressive;
         break;
+    case "=cqo":
     case "cqo":
         autoLink = enums.autoLinkOption.codeQuoteOnly;
         break;

--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -5,12 +5,14 @@ var path = require('path');
 var argv = require('minimist')(process.argv.slice(2), { boolean : ["w", "suppresswarnings" ]});
 var defined = require('../lib/defined');
 var defaultValue = require('../lib/defaultValue');
-var generateMarkdown = require('../');
+var enums = require('../lib/enums');
+var generateMarkdown = require('../lib/generateMarkdown');
 
 if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
     var help = 'Usage: node ' + path.basename(__filename) + ' [path-to-json-schema-file] [OPTIONS]\n' +
         '  -l,  --headerLevel        Top-level header. Default: 1\n' +
         '  -p,  --schemaPath         The path string that should be used when generating the schema reference paths.\n' +
+        '  -al, --autoLink           Aggressively auto-inter-link types referenced in descriptions.  Add =cqo to auto-link types that are in code-quotes only.\n' +
         '  -d,  --debug              Provide a path, and this will save out intermediate processing artifacts useful in debugging wetzel.' +
         '  -w,  --suppressWarnings   Will not print out WETZEL_WARNING strings indicating identified conversion problems. Default: false';
     process.stdout.write(help);
@@ -19,6 +21,16 @@ if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
 
 var filepath = argv._[0];
 var schema = JSON.parse(fs.readFileSync(filepath));
+
+var autoLink = enums.autoLinkOption.off;
+switch (defaultValue(argv.al, argv.autoLink)) {
+    case true:
+        autoLink = enums.autoLinkOption.aggressive;
+        break;
+    case "cqo":
+        autoLink = enums.autoLinkOption.codeQuoteOnly;
+        break;
+}
 
 process.stdout.write(generateMarkdown({
     schema: schema,
@@ -29,4 +41,5 @@ process.stdout.write(generateMarkdown({
     schemaRelativeBasePath: defaultValue(defaultValue(argv.p, argv.schemaPath), null),
     debug: defaultValue(defaultValue(argv.d, argv.debug), null),
     suppressWarnings: defaultValue(defaultValue(argv.w, argv.suppressWarnings), false),
+    autoLink: autoLink,
 }));

--- a/lib/enums.js
+++ b/lib/enums.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var autoLinkOption = {
+    'off': 'off',
+    'aggressive': 'agressive',
+    'codeQuoteOnly': 'codeQuoteOnly'
+};
+
+module.exports = {
+    /**
+    * Indicates the possible resulting values for the autoLink commandline parameter
+    */
+    autoLinkOption: autoLinkOption
+};

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -8,6 +8,7 @@ var clone = require('./clone');
 var style = require('./style');
 var schema3 = require('./schema3Resolver');
 var schema4 = require('./schema4Resolver');
+var enums = require('./enums');
 
 module.exports = generateMarkdown;
 
@@ -55,7 +56,8 @@ function generateMarkdown(options) {
             options.headerLevel + 1,
             options.suppressWarnings,
             options.schemaRelativeBasePath,
-            orderedTypesDescending);
+            orderedTypesDescending,
+            options.autoLink);
     }
     
     return md;
@@ -74,7 +76,9 @@ function generateMarkdown(options) {
 function getTableOfContentsMarkdown(schema, orderedTypes, headerLevel) {
     var md = style.getHeaderMarkdown(headerLevel) + ' Objects\n';
     for (var type in orderedTypes) {
-        md += style.bulletItem(style.linkType('`' + type + '`', type) + (type === schema.title ? ' (root object)' : ''));
+        // Regardless of what the user chooses for how types are auto-linked, we'll always
+        // link the table-of-contents options.
+        md += style.bulletItem(style.linkType(style.typeValue(type), type, enums.autoLinkOption.codeQuoteOnly) + (type === schema.title ? ' (root object)' : ''));
     }
 
     return md;
@@ -90,9 +94,10 @@ function getTableOfContentsMarkdown(schema, orderedTypes, headerLevel) {
 * @param  {string} schemaRelativeBasePath The path, relative to where this documentation lives, that the schema files can be found.
 * Leave as null if you don't want the documentation to link to the schema files. 
 * @param  {object} knownTypes             The dictionary of types and their schema information.
+* @param  {string} autoLink               Enum value indicating how the auto-linking should be handled.
 * @return {string}                        The markdown for the schema.
 */
-function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, schemaRelativeBasePath, knownTypes) {
+function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, schemaRelativeBasePath, knownTypes, autoLink) {
     var md = '';
 
     // Render section header
@@ -100,7 +105,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
     md += style.getSectionMarkdown(title, headerLevel);
 
     // Render description
-    var value = autoLinkDescription(schema.description, knownTypes);
+    var value = autoLinkDescription(schema.description, knownTypes, autoLink);
     if (defined(value)) {
         md += value + '\n\n';
     }
@@ -120,7 +125,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
     // Render each property if the type is object
     if (schemaType === 'object') {
         // Render table with summary of each property
-        md += createPropertiesSummary(schema, knownTypes);
+        md += createPropertiesSummary(schema, knownTypes, autoLink);
 
         value = schema.additionalProperties;
         if (defined(value) && !value) {
@@ -140,7 +145,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
         }
 
         // Render section for each property
-        md += createPropertiesDetails(schema, title, headerLevel + 1, knownTypes);
+        md += createPropertiesDetails(schema, title, headerLevel + 1, knownTypes, autoLink);
     }
 
     return md;
@@ -148,7 +153,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
 
 ////////////////////////////////////////////////////////////////////////////////
 
-function createPropertiesSummary(schema, knownTypes) {
+function createPropertiesSummary(schema, knownTypes, autoLink) {
     var md = '';
 
     md += style.propertiesSummary('Properties') + '\n\n';
@@ -159,7 +164,7 @@ function createPropertiesSummary(schema, knownTypes) {
     for (var name in properties) {
         if (properties.hasOwnProperty(name)) {
             var property = properties[name];
-            var summary = getPropertySummary(property, knownTypes);
+            var summary = getPropertySummary(property, knownTypes, autoLink);
 
             md += '|' + style.propertyNameSummary(name) +
                 '|' + summary.formattedType +
@@ -173,7 +178,7 @@ function createPropertiesSummary(schema, knownTypes) {
     return md;
 }
 
-function createPropertiesDetails(schema, title, headerLevel, knownTypes) {
+function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLink) {
     var headerMd = style.getHeaderMarkdown(headerLevel);
     var md = '';
 
@@ -182,12 +187,12 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes) {
         if (properties.hasOwnProperty(name)) {
             var property = properties[name];
             var type = property.type;
-            var summary = getPropertySummary(property, knownTypes);
+            var summary = getPropertySummary(property, knownTypes, autoLink);
 
             md += headerMd + ' ' + title + '.' + name + (summary.required === 'Yes' ? style.requiredIcon : '') + '\n\n';
 
             // TODO: Add plugin point for custom JSON schema properties like gltf_*
-            var detailedDescription = autoLinkDescription(property.gltf_detailedDescription, knownTypes);
+            var detailedDescription = autoLinkDescription(property.gltf_detailedDescription, knownTypes, autoLink);
             if (defined(detailedDescription)) {
                 md += detailedDescription + '\n\n';
             } else if (defined(summary.description)) {
@@ -269,7 +274,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes) {
                     var formattedType = style.typeValue(additionalProperties.type)
                     if ((additionalProperties.type === 'object') && defined(property.title))
                     {
-                        formattedType = style.linkType(property.title, property.title);
+                        formattedType = style.linkType(property.title, property.title, autoLink);
                     }
 
                     md += '* ' + style.propertyDetails('Type of each property') + ': ' + formattedType + '\n';
@@ -290,7 +295,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes) {
     return md;
 }
 
-function getPropertySummary(property, knownTypes) {
+function getPropertySummary(property, knownTypes, autoLink) {
     var type = defaultValue(property.type, 'any');
     var formattedType = style.typeValue(type);
 
@@ -315,7 +320,7 @@ function getPropertySummary(property, knownTypes) {
         if (defined(property.items) && defined(property.items.type)) {
             if ((property.items.type === 'object') && defined(property.items.title)) {
                 type = property.items.title;
-                formattedType = style.linkType(type, type);
+                formattedType = style.linkType(type, type, autoLink);
 
                 type += arrayInfo;
                 formattedType += style.typeValue(arrayInfo);
@@ -329,7 +334,7 @@ function getPropertySummary(property, knownTypes) {
         }
     }
 
-    var description = autoLinkDescription(property.description, knownTypes);
+    var description = autoLinkDescription(property.description, knownTypes, autoLink);
 
     var required;
     if (defined(property.required) && (property.required)) {
@@ -392,11 +397,12 @@ function getEnumString(schema, type) {
 * @param  {type} description The string that should be auto-linked
 * @param  {string[]} knownTypes  Array of known strings that are types that should be auto-linked if found.
 * If there are multiple types with the same starting root string, it's imperative that the array is sorted such that the longer names are ordered first.
+* @param  {string} autoLink Enum value indicating how the auto-linking should be handled.
 * @return {string} The auto-linked description.
 */
-function autoLinkDescription(description, knownTypes) {
+function autoLinkDescription(description, knownTypes, autoLink) {
     for (var type in knownTypes) {
-        description = style.linkType(description, type);
+        description = style.linkType(description, type, autoLink);
     }
 
     return description;

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -74,7 +74,7 @@ function generateMarkdown(options) {
 function getTableOfContentsMarkdown(schema, orderedTypes, headerLevel) {
     var md = style.getHeaderMarkdown(headerLevel) + ' Objects\n';
     for (var type in orderedTypes) {
-        md += style.bulletItem(style.linkType(type, type) + (type === schema.title ? ' (root object)' : ''));
+        md += style.bulletItem(style.linkType('`' + type + '`', type) + (type === schema.title ? ' (root object)' : ''));
     }
 
     return md;

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var defined = require('./defined');
 var defaultValue = require('./defaultValue');
+var sortObject = require('./sortObject');
 var clone = require('./clone');
 var style = require('./style');
 var schema3 = require('./schema3Resolver');
@@ -23,26 +24,83 @@ function generateMarkdown(options) {
 
     // Verify JSON Schema version
     var schemaRef = schema.$schema;
+    var resolved = null;
     if (defined(schemaRef)) {
         if (schemaRef === 'http://json-schema.org/draft-03/schema') {
-            schema = schema3.resolve(schema, options.basePath, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.debug);
         }
         else if (schemaRef === 'http://json-schema.org/draft-04/schema') {
-            schema = schema4.resolve(schema, options.basePath, options.debug);
+            resolved = schema4.resolve(schema, options.fileName, options.basePath, options.debug);
         }
         else
         {
-            schema = schema3.resolve(schema, options.basePath, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.debug);
             md += '> WETZEL_WARNING: Only JSON Schema 3 or 4 is supported. Treating as Schema 3.\n\n';
         }
     }
 
-    // Render title
-    var title = defaultValue(schema.title, options.suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
-    md += style.getHeaderMarkdown(options.headerLevel) + ' ' + title + '\n\n';
+    schema = resolved.schema;
+    var orderedTypes = sortObject(resolved.referencedSchemas);
+
+    // We need the reverse-sorted version so that when we do type searching we find the longest type first.
+    var orderedTypesDescending = sortObject(resolved.referencedSchemas, false);
+
+    md += getTableOfContentsMarkdown(schema, orderedTypes, options.headerLevel);
+
+    for (var type in orderedTypes) {
+        md += '\n\n';
+        md += getSchemaMarkdown(
+            orderedTypes[type].schema,
+            orderedTypes[type].fileName,
+            options.headerLevel + 1,
+            options.suppressWarnings,
+            options.schemaRelativeBasePath,
+            orderedTypesDescending);
+    }
+    
+    return md;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+* @function getTableOfContentsMarkdown
+* Print a table of contents indicating (and linking to) all of the types that are documented
+* @param  {object} schema       The root schema that the documentation is for.
+* @param  {object} orderedTypes The ordered collection of types for the TOC.
+* @param  {int} headerLevel     The level that the header for the TOC should be displayed at.
+* @return {string} The markdown for the table of contents.
+*/
+function getTableOfContentsMarkdown(schema, orderedTypes, headerLevel) {
+    var md = style.getHeaderMarkdown(headerLevel) + ' Objects\n';
+    for (var type in orderedTypes) {
+        md += style.bulletItem(style.linkType(type, type) + (type === schema.title ? ' (root object)' : ''));
+    }
+
+    return md;
+}
+
+/**
+* @function getSchemaMarkdown
+* Gets the markdown for the first-class elements of a schema.
+* @param  {object} schema                 The schema being converted to markdown.
+* @param  {string} fileName               The filename of the schema being converted to markdown.
+* @param  {int} headerLevel               The starting level for the headers.
+* @param  {boolean} suppressWarnings      Indicates if wetzel warnings should be printed in the documentation.
+* @param  {string} schemaRelativeBasePath The path, relative to where this documentation lives, that the schema files can be found.
+* Leave as null if you don't want the documentation to link to the schema files. 
+* @param  {object} knownTypes             The dictionary of types and their schema information.
+* @return {string}                        The markdown for the schema.
+*/
+function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, schemaRelativeBasePath, knownTypes) {
+    var md = '';
+
+    // Render section header
+    var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
+    md += style.getSectionMarkdown(title, headerLevel);
 
     // Render description
-    var value = schema.description;
+    var value = autoLinkDescription(schema.description, knownTypes);
     if (defined(value)) {
         md += value + '\n\n';
     }
@@ -62,7 +120,7 @@ function generateMarkdown(options) {
     // Render each property if the type is object
     if (schemaType === 'object') {
         // Render table with summary of each property
-        md += createPropertiesSummary(schema, options.suppressWarnings);
+        md += createPropertiesSummary(schema, knownTypes);
 
         value = schema.additionalProperties;
         if (defined(value) && !value) {
@@ -72,8 +130,17 @@ function generateMarkdown(options) {
             // TODO: display their schema
         }
 
+        // Schema reference
+        if (defined(schemaRelativeBasePath))
+        {
+            md += style.bulletItem(style.bold('JSON schema') + ': ' + style.getLinkMarkdown(fileName, path.join(schemaRelativeBasePath, fileName).replace(/\\/g, '/'))) + '\n';
+
+            // TODO: figure out how to auto-determine example reference
+            //* **Example**: [bufferViews.json](schema/examples/bufferViews.json)
+        }
+
         // Render section for each property
-        md += createPropertiesDetails(schema, title, options.headerLevel + 1, options.suppressWarnings);
+        md += createPropertiesDetails(schema, title, headerLevel + 1, knownTypes);
     }
 
     return md;
@@ -81,8 +148,9 @@ function generateMarkdown(options) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-function createPropertiesSummary(schema, suppressWarnings) {
+function createPropertiesSummary(schema, knownTypes) {
     var md = '';
+
     md += style.propertiesSummary('Properties') + '\n\n';
     md += '|   |Type|Description|Required|\n';
     md += '|---|----|-----------|--------|\n';
@@ -91,20 +159,21 @@ function createPropertiesSummary(schema, suppressWarnings) {
     for (var name in properties) {
         if (properties.hasOwnProperty(name)) {
             var property = properties[name];
-            var summary = getPropertySummary(property, suppressWarnings);
+            var summary = getPropertySummary(property, knownTypes);
 
             md += '|' + style.propertyNameSummary(name) +
-                '|' + style.typeValue(summary.type) +
+                '|' + summary.formattedType +
                 '|' + defaultValue(summary.description, '') +
                 '|' + (summary.required === 'Yes' ? style.requiredIcon : '') + summary.required + '|\n';
         }
     }
+
     md += '\n';
 
     return md;
 }
 
-function createPropertiesDetails(schema, title, headerLevel, suppressWarnings) {
+function createPropertiesDetails(schema, title, headerLevel, knownTypes) {
     var headerMd = style.getHeaderMarkdown(headerLevel);
     var md = '';
 
@@ -113,19 +182,19 @@ function createPropertiesDetails(schema, title, headerLevel, suppressWarnings) {
         if (properties.hasOwnProperty(name)) {
             var property = properties[name];
             var type = property.type;
-            var summary = getPropertySummary(property, suppressWarnings);
+            var summary = getPropertySummary(property, knownTypes);
 
             md += headerMd + ' ' + title + '.' + name + (summary.required === 'Yes' ? style.requiredIcon : '') + '\n\n';
 
             // TODO: Add plugin point for custom JSON schema properties like gltf_*
-            var detailedDescription = property.gltf_detailedDescription;
+            var detailedDescription = autoLinkDescription(property.gltf_detailedDescription, knownTypes);
             if (defined(detailedDescription)) {
                 md += detailedDescription + '\n\n';
             } else if (defined(summary.description)) {
                 md += summary.description + '\n\n';
             }
 
-            md += '* ' + style.propertyDetails('Type') + ': ' + style.typeValue(summary.type) + '\n';
+            md += '* ' + style.propertyDetails('Type') + ': ' + summary.formattedType + '\n';
 
             var uniqueItems = property.uniqueItems;
             if (defined(uniqueItems) && uniqueItems) {
@@ -197,7 +266,13 @@ function createPropertiesDetails(schema, title, headerLevel, suppressWarnings) {
             if (defined(additionalProperties) && (typeof additionalProperties === 'object')) {
                 if (defined(additionalProperties.type)) {
                     // TODO: additionalProperties is really a full schema
-                    md += '* ' + style.propertyDetails('Type of each property') + ': ' + style.typeValue(additionalProperties.type) + '\n';
+                    var formattedType = style.typeValue(additionalProperties.type)
+                    if ((additionalProperties.type === 'object') && defined(property.title))
+                    {
+                        formattedType = style.linkType(property.title, property.title);
+                    }
+
+                    md += '* ' + style.propertyDetails('Type of each property') + ': ' + formattedType + '\n';
                 }
             }
 
@@ -215,8 +290,10 @@ function createPropertiesDetails(schema, title, headerLevel, suppressWarnings) {
     return md;
 }
 
-function getPropertySummary(property, suppressWarnings) {
-    var type = defaultValue(property.type, suppressWarnings ? '' : 'WETZEL_WARNING: type not defined');
+function getPropertySummary(property, knownTypes) {
+    var type = defaultValue(property.type, 'any');
+    var formattedType = style.typeValue(type);
+
     if (type === 'array') {
         var insideBrackets = '';
         if ((defined(property.minItems)) && (property.minItems === property.maxItems)) {
@@ -233,14 +310,26 @@ function getPropertySummary(property, suppressWarnings) {
             insideBrackets = '*-' + property.maxItems;
         }
 
-        if (defined(property.items) && defined(property.items.type)) {
-            type = property.items.type;
-        }
+        var arrayInfo = '[' + insideBrackets + ']';
 
-        type += '[' + insideBrackets + ']';
+        if (defined(property.items) && defined(property.items.type)) {
+            if ((property.items.type === 'object') && defined(property.items.title)) {
+                type = property.items.title;
+                formattedType = style.linkType(type, type);
+
+                type += arrayInfo;
+                formattedType += style.typeValue(arrayInfo);
+            } else {
+                type = property.items.type + arrayInfo;
+                formattedType = style.typeValue(type);
+            }
+        } else {
+            type += arrayInfo;
+            formattedType = style.typeValue(type);
+        }
     }
 
-    var description = property.description;
+    var description = autoLinkDescription(property.description, knownTypes);
 
     var required;
     if (defined(property.required) && (property.required)) {
@@ -265,6 +354,7 @@ function getPropertySummary(property, suppressWarnings) {
 
     return {
         type: type,
+        formattedType: formattedType,
         description: description,
         required: required
     };
@@ -292,4 +382,22 @@ function getEnumString(schema, type) {
         }
     }
     return allowedValues;
+}
+
+/**
+* @function autoLinkDescription
+* This will take a string that describes a type that may potentially reference _other_ types, and then
+* automatically add markdown link refences to those other types inline. This is an admittedly simple
+* (and potentially buggy) approach to the problem, but seems sufficient for the needs of glTF.
+* @param  {type} description The string that should be auto-linked
+* @param  {string[]} knownTypes  Array of known strings that are types that should be auto-linked if found.
+* If there are multiple types with the same starting root string, it's imperative that the array is sorted such that the longer names are ordered first.
+* @return {string} The auto-linked description.
+*/
+function autoLinkDescription(description, knownTypes) {
+    for (var type in knownTypes) {
+        description = style.linkType(description, type);
+    }
+
+    return description;
 }

--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -1,9 +1,13 @@
 "use strict";
 var defined = require('./defined');
+var defaultValue = require('./defaultValue');
 var path = require('path');
 var fs = require('fs');
 
 module.exports = replaceRef;
+
+// TODO: allow this to be command-line configurable
+var ignorableTypes = ['gltfid.schema.json', 'gltfchildofrootproperty.schema.json', 'gltfproperty.schema.json'];
 
 /**
 * @function replaceRef
@@ -12,21 +16,28 @@ module.exports = replaceRef;
 * @todo Does not currently support absolute reference paths, only relative paths.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {object} schemaReferences - An object that will be populated with all schemas referenced by this object
 * @return {object} The schema object with all schema file referenced replaced with the actual file content.
 */
-function replaceRef(schema, basePath) {
+function replaceRef(schema, basePath, schemaReferences) {
+    schemaReferences = defaultValue(schemaReferences, {});
+
     var ref = schema.$ref;
     if (defined(ref)) {
         // TODO: $ref could also be absolute.
-        var filename = path.join(basePath, ref);
-        var refSchema = JSON.parse(fs.readFileSync(filename));
-        return replaceRef(refSchema, basePath);
+        var filePath = path.join(basePath, ref);
+        var refSchema = JSON.parse(fs.readFileSync(filePath));
+        if (ignorableTypes.indexOf(ref.toLowerCase()) < 0) {
+            schemaReferences[refSchema.title] = { schema: refSchema, fileName: ref };
+        }
+        
+        return replaceRef(refSchema, basePath, schemaReferences);
     }
 
     for (var name in schema) {
         if (schema.hasOwnProperty(name)) {
             if (typeof schema[name] === 'object') {
-                schema[name] = replaceRef(schema[name], basePath);
+                schema[name] = replaceRef(schema[name], basePath, schemaReferences);
             }
         }
     }

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -14,32 +14,46 @@ module.exports = { resolve: resolve };
 * by replacing json schema references ($ref) with the actual content, and then merging
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
+* @param  {string} fileName - The name of this schema file.
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
-* @return {object} The resolved schema object
+* @return {object} The resolved schema object and its collection of referenced schemas
 */
-function resolve(schema, basePath, debugOutputPath) {
+function resolve(schema, fileName, basePath, debugOutputPath) {
+    // work off a cloned schema so that we're not modifying input objects
+    var schemaClone = clone(schema, true);
+    var referencedSchemas = {};
+
     if (null !== debugOutputPath) {
-        fs.writeFileSync(debugOutputPath + ".original.json", JSON.stringify(schema), function (err) {
+        fs.writeFileSync(debugOutputPath + ".original.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }
         });
     }
 
-    schema = replaceRef(schema, basePath);
+    referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName };
+    schemaClone = replaceRef(schemaClone, basePath, referencedSchemas);
     if (null !== debugOutputPath) {
-        fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schema), function (err) {
+        fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }
         });
     }
     
-    extend(schema);
+    extend(schemaClone);
     if (null !== debugOutputPath) {
-        fs.writeFileSync(debugOutputPath + ".schema3.resolved.json", JSON.stringify(schema), function (err) {
+        fs.writeFileSync(debugOutputPath + ".schema3.resolved.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }
         });
     }
 
-    return schema;
+    // Need to process all of the individual referenced schemas as well so that they're ready for conversion.
+    for (var type in referencedSchemas) {
+        extend(referencedSchemas[type].schema);
+    }
+
+    return {
+        schema: schemaClone,
+        referencedSchemas: referencedSchemas
+    };
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -155,18 +155,18 @@ function normalizeRequired(schema) {
         return schema;
     }
 
+    // Transfer required to a local variable.
+    var requiredProperties = Array.isArray(schema.required) ? schema.required : [];
+    schema.required = undefined;
+
     for (var name in schema.properties) {
         if (schema.properties.hasOwnProperty(name)) {
             var property = schema.properties[name];
-            if (!defined(property.required) &&
-                defined(schema.required) &&
-                Array.isArray(schema.required) &&
-                schema.required.indexOf(name) >= 0)
-            {
+            property = normalizeRequired(property);
+
+            if (requiredProperties.indexOf(name) >= 0) {
                 property.required = true;
             }
-
-            property = normalizeRequired(property);
         }
     }
 

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -77,7 +77,7 @@ function resolveInheritance(derived) {
     if (defined(base)) {
         resolveInheritance(base);
 
-        for (var singleBase in base) {;
+        for (var singleBase in base) {
             mergeProperties(derived, base[singleBase]);
         }
 

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -14,39 +14,52 @@ module.exports = { resolve: resolve };
 * by replacing json schema references ($ref) with the actual content, and then merging
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
+* @param  {string} fileName - The name of this schema file.
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
-* @return {object} The resolved schema object
+* @return {object} The resolved schema object and its collection of referenced schemas
 */
-function resolve(schema, basePath, debugOutputPath) {
+function resolve(schema, fileName, basePath, debugOutputPath) {
+    // work off a cloned schema so that we're not modifying input objects
+    var schemaClone = clone(schema, true);
+    var referencedSchemas = {};
+
     if (null !== debugOutputPath) {
-        fs.writeFileSync(debugOutputPath + ".original.json", JSON.stringify(schema), function (err) {
+        fs.writeFileSync(debugOutputPath + ".original.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }
         });
     }
 
-    schema = replaceRef(schema, basePath);
+    referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName };
+    schemaClone = replaceRef(schemaClone, basePath, referencedSchemas);
     if (null !== debugOutputPath) {
-        fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schema), function (err) {
+        fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }
         });
     }
 
-    resolveInheritance(schema);
+    resolveInheritance(schemaClone);
     if (null !== debugOutputPath) {
-        fs.writeFileSync(debugOutputPath + ".schema4.resolved.json", JSON.stringify(schema), function (err) {
+        fs.writeFileSync(debugOutputPath + ".schema4.resolved.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }
         });
     }
 
-    normalizeRequired(schema);
+    normalizeRequired(schemaClone);
     if (null !== debugOutputPath) {
-        fs.writeFileSync(debugOutputPath + ".schema4.requiredNormalized.json", JSON.stringify(schema), function (err) {
+        fs.writeFileSync(debugOutputPath + ".schema4.requiredNormalized.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }
         });
     }
 
-    return schema;
+    // Need to process all of the individual referenced schemas as well so that they're ready for conversion.
+    for (var type in referencedSchemas) {
+        resolveInheritance(referencedSchemas[type].schema);
+        normalizeRequired(referencedSchemas[type].schema);
+    }
+
+    return { schema: schemaClone,
+             referencedSchemas: referencedSchemas};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -64,7 +77,7 @@ function resolveInheritance(derived) {
     if (defined(base)) {
         resolveInheritance(base);
 
-        for (var singleBase in base) {
+        for (var singleBase in base) {;
             mergeProperties(derived, base[singleBase]);
         }
 
@@ -134,15 +147,16 @@ function mergeProperties(derived, base) {
 * references properties by name that should be considered required.  We'll normalize
 * to bool attributes on the individual properties so that the markdown generation
 * logic can be shared amongst the different schema resolvers.
-* By design, this isn't recursively normalizing the schema.  We only care about
-* the first level within the schema, as we'll re-process the nested schemas
-* separately.
 * @param  {object} schema - The json schema object that needs the 'required' properties to be normalized.
 * @return {object} The normalized json schema object
 */
 function normalizeRequired(schema) {
+    if (!defined(schema.properties) || !schema.hasOwnProperty('properties')) {
+        return schema;
+    }
+
     for (var name in schema.properties) {
-        if (schema.properties.hasOwnProperty(name)){
+        if (schema.properties.hasOwnProperty(name)) {
             var property = schema.properties[name];
             if (!defined(property.required) &&
                 defined(schema.required) &&
@@ -151,6 +165,8 @@ function normalizeRequired(schema) {
             {
                 property.required = true;
             }
+
+            property = normalizeRequired(property);
         }
     }
 

--- a/lib/sortObject.js
+++ b/lib/sortObject.js
@@ -1,0 +1,59 @@
+"use strict";
+var defaultValue = require('./defaultValue');
+
+module.exports = getSortedObjectByKey;
+
+/**
+* @function getSortedObjectByKey
+* Returns a new object that has the original object's keys/values sorted.
+* @param  {object} object The object to be sorted by key.
+* @param  {boolean} ascending Indicates if it should be sorted ascending (true) or descending (false)
+* @return {object} The sorted object
+*/
+function getSortedObjectByKey(object, ascending) {
+    ascending = defaultValue(ascending, true);
+
+    var keys = Object.keys(object);
+
+    var sortedKeys = keys.sort(ascending ? sortAscending : sortDescending);
+    
+    var sortedObject = {};
+    for (var index in keys) {
+        var key = keys[index];
+        sortedObject[key] = object[key];
+    }
+
+    return sortedObject;
+}
+
+/**
+* @function sortAscending
+* Sort method used to sort keys in ascending order.
+* @param  {type} key1 The first key to compare
+* @param  {type} key2 The second key to compare
+* @return {int} 0 of the keys are identical; -1 if key1 should be sorted earlier than key2; 1 otherwise.
+*/
+function sortAscending(key1, key2)
+{
+    key1 = key1.toLowerCase();
+    key2 = key2.toLowerCase();
+    if (key1 < key2) return -1;
+    if (key1 > key2) return 1;
+    return 0;
+}
+
+/**
+* @function sortDescending
+* Sort method used to sort keys in descending order.
+* @param  {type} key1 The first key to compare
+* @param  {type} key2 The second key to compare
+* @return {int} 0 of the keys are identical; -1 if key1 should be sorted earlier than key2; 1 otherwise.
+*/
+function sortDescending(key1, key2)
+{
+    key1 = key1.toLowerCase();
+    key2 = key2.toLowerCase();
+    if (key1 > key2) return -1;
+    if (key1 < key2) return 1;
+    return 0;
+}

--- a/lib/style.js
+++ b/lib/style.js
@@ -1,8 +1,23 @@
 "use strict";
 var defined = require('./defined');
+var defaultValue = require('./defaultValue');
 
 module.exports = {
     getHeaderMarkdown: getHeaderMarkdown,
+
+    getSectionMarkdown: getSectionMarkdown,
+
+    getLinkMarkdown: getLinkMarkdown,
+
+    bulletItem: bulletItem,
+
+    /**
+    * @function bold
+    * Bold the specified string
+    * @param  {string} string - The string to be styled
+    * @return {string} The string styled as bolded for display in markdown.
+    */
+    bold: styleBold,
 
     /**
     * @function type
@@ -86,6 +101,8 @@ module.exports = {
     */
     minMax: styleCode,
 
+    linkType: linkType,
+
     /**
     * @property {string} The markdown string used for displaying the icon used to indicate a value is required.
     */
@@ -105,6 +122,60 @@ function getHeaderMarkdown(level) {
     }
 
     return md;
+}
+
+/**
+* @function getSectionMarkdown
+* Gets the markdown syntax for the start of a section.
+* @param  {string} section - The name of the section
+* @param  {int} level - The header lever that is being requested
+* @return {string} The markdown string that should be placed as the start of the section
+*/
+function getSectionMarkdown(section, level) {
+    var md = '';
+
+    md += '---------------------------------------\n';
+    md += '<a name="reference-' + section.toLowerCase().replace(/ /g, '-') + '"></a>\n';
+    md += getHeaderMarkdown(level) + ' ' + section + '\n\n';
+
+    return md;
+}
+
+/**
+* @function getSectionMarkdown
+* Gets the markdown syntax for a bulleted item.
+* @param  {string} item - The item being bulleted.
+* @param  {int} indentationLevel - The number of indentation levels that should be applied
+* @return {string} The markdown string representing the item as a bulleted item at the proper indentation.
+*/
+function bulletItem(item, indentationLevel) {
+    var md = '';
+
+    indentationLevel = defaultValue(indentationLevel, 0);
+
+    for (var i = 0; i < indentationLevel; ++i) {
+        md += '   ';
+    }
+
+    md = '* ' + item + '\n';
+    return md;
+}
+
+/**
+* @function getLinkMarkdown
+* Creates a markdown link
+* @param  {string} string - The string to be linked
+* @param  {string} link - The link that should be applied to the string
+* @return {string} The markdown with the specified string hyperlinked to the specified link.
+*/
+function getLinkMarkdown(string, link) {
+    if ((!defined(string) || string.length === 0)) {
+        return '';
+    } else if ((!defined(link) || link.length === 0)) {
+        return string;
+    } else {
+        return '[' + string + '](' + link + ')';
+    }
 }
 
 /**
@@ -129,7 +200,7 @@ function styleBold(string) {
 */
 function styleCode(string) {
     if (defined(string) && string.length > 0) {
-        return '`' + string + '`'
+        return '`' + string + '`';
     }
 
     return '';
@@ -150,4 +221,23 @@ function styleCodeType(string, type) {
     }
 
     return styleCode(string);
+}
+
+/**
+* @function linkType
+* Finds any occurrence of type in the provided string, and adds a markdown link to it.
+* @param  {string} string - The string that might be referencing a type
+* @param  {string} type - The type whose reference within string should be linked.
+* @return {string} The updated string, with any occurrences of the @type string linked via markdown.
+*/
+function linkType(string, type) {
+    if ((!defined(string) || string.length === 0)) {
+        return string;
+    } else if ((!defined(type) || type.length === 0)) {
+        return string;
+    } else {
+        var typeLink = '#reference-' + type.toLowerCase().replace(/ /g, '-');
+        var regExp = new RegExp('([^`\.]|^)' + type + '([ \.]|$)');
+        return string.replace(regExp, "$1[" + styleCode(type) + '](' + typeLink + ")$2");
+    }
 }

--- a/lib/style.js
+++ b/lib/style.js
@@ -1,6 +1,7 @@
 "use strict";
 var defined = require('./defined');
 var defaultValue = require('./defaultValue');
+var enums = require('./enums');
 
 module.exports = {
     getHeaderMarkdown: getHeaderMarkdown,
@@ -234,16 +235,26 @@ function styleCodeType(string, type) {
 * Finds any occurrence of type in the provided string, and adds a markdown link to it.
 * @param  {string} string - The string that might be referencing a type
 * @param  {string} type - The type whose reference within string should be linked.
+* @param  {string} autoLink - The enum value indicating how the auto-linking should be handled.
 * @return {string} The updated string, with any occurrences of the @type string linked via markdown.
 */
-function linkType(string, type) {
-    if ((!defined(string) || string.length === 0)) {
+function linkType(string, type, autoLink) {
+    if (defaultValue(autoLink, enums.autoLinkOption.off) === enums.autoLinkOption.off) {
+        return string;
+    } else if ((!defined(string) || string.length === 0)) {
         return string;
     } else if ((!defined(type) || type.length === 0)) {
         return string;
     } else {
         var typeLink = '#reference-' + type.toLowerCase().replace(/ /g, '-');
-        var regExp = new RegExp('`' + type + '`');
-        return string.replace(regExp, "[" + styleCode(type) + '](' + typeLink + ")");
+
+        if (autoLink === enums.autoLinkOption.aggressive)
+        {
+            var regExp = new RegExp('([^`\.]|^)' + type + '([ \.]|$)');
+            return string.replace(regExp, "$1[" + styleCode(type) + '](' + typeLink + ")$2");
+        } else {
+            var regExp = new RegExp('`' + type + '`');
+            return string.replace(regExp, "[" + styleCode(type) + '](' + typeLink + ")");
+        }
     }
 }

--- a/lib/style.js
+++ b/lib/style.js
@@ -96,7 +96,7 @@ module.exports = {
     /**
     * @function minMax
     * Format a minimum or maximum value for display in markdown
-    * @param  {string} string - The minimum/maximum value to be styled
+    * @param  {int} value - The minimum/maximum value to be styled
     * @return {string} The minimum or maximum value styled for display in markdown.
     */
     minMax: styleCode,
@@ -194,13 +194,19 @@ function styleBold(string) {
 
 /**
 * @function styleCode
-* Returns back a markdown string that displays the provided string as code.
-* @param  {string} string - The string to be displayed as code
-* @return {string} The string in markdown code syntax
+* Returns back a markdown string that displays the provided object as code.
+* @param  {object} code - The object to be displayed as code. It might be a string, or a number, or ...
+* @return {string} The code in markdown code syntax
 */
-function styleCode(string) {
-    if (defined(string) && string.length > 0) {
-        return '`' + string + '`';
+function styleCode(code) {
+    if (defined(code)) {
+        // The object might be a string or it might be a number or something else.
+        // Let's make sure it's a string first.
+        var stringified = code.toString();
+
+        if (stringified.length > 0) {
+            return '`' + stringified + '`';
+        }
     }
 
     return '';

--- a/lib/style.js
+++ b/lib/style.js
@@ -243,7 +243,7 @@ function linkType(string, type) {
         return string;
     } else {
         var typeLink = '#reference-' + type.toLowerCase().replace(/ /g, '-');
-        var regExp = new RegExp('([^`\.]|^)' + type + '([ \.]|$)');
-        return string.replace(regExp, "$1[" + styleCode(type) + '](' + typeLink + ")$2");
+        var regExp = new RegExp('`' + type + '`');
+        return string.replace(regExp, "[" + styleCode(type) + '](' + typeLink + ")");
     }
 }


### PR DESCRIPTION
This update allows wetzel to generate complete
documentation for a schema with auto-linking
between type references.

* Schema resolvers now return back the resolved
  schema, along with a dictionary of all the other
  schemas that are referenced along the way (e.g.
  `knownTypes`).

* The `knownTypes` dictionary becomes the Table of Contents
  and then all of those types have their markdown
  generated.

* Some simple heuristics are applied to displayed types
  and typenames within descriptions to attempt to link
  those references to the type definition within the
  markdown.

  * These heuristics are pretty basic. If the current output
    isn't what's desired in the end, we should consider
    having a human update the glTF schema itself, adding
    markdown code tag around any type within a description
    that makes sense to be linked, and then update the
    logic of `style.linkType` to only link those type names.
    At present, the schema is inconsistent with when type names
    are markdown code-stylized.

 * New styles added to handle the linking of types

 * Resolves issue #6: Update README.md to account for JSON Schema 4
