### PR TITLE
id map and forgiving schemaRef

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -24,10 +24,10 @@ function generateMarkdown(options) {
     // Verify JSON Schema version
     var schemaRef = schema.$schema;
     if (defined(schemaRef)) {
-        if (schemaRef === 'http://json-schema.org/draft-03/schema') {
+        if (schemaRef.indexOf('//json-schema.org/draft-03/schema') >= 0) {
             schema = schema3.resolve(schema, options.basePath, options.debug);
         }
-        else if (schemaRef === 'http://json-schema.org/draft-04/schema') {
+        else if (schemaRef.indexOf('//json-schema.org/draft-04/schema') >= 0) {
             schema = schema4.resolve(schema, options.basePath, options.debug);
         }
         else

--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -14,8 +14,20 @@ module.exports = replaceRef;
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
 * @return {object} The schema object with all schema file referenced replaced with the actual file content.
 */
+var idmap = {}
 function replaceRef(schema, basePath) {
     var ref = schema.$ref;
+    // Look through top level schema definitions and store them by id
+    if (schema.hasOwnProperty('definitions') && Object.getOwnPropertyNames(idmap).length == 0) {
+        for (var def in schema.definitions) {
+           idmap[schema.definitions[def].id] = schema.definitions[def]
+        }
+    }
+    // If the ref is against a defined id, replace it
+    if (idmap.hasOwnProperty(ref)) {
+      return replaceRef(idmap[ref], basePath);
+    }
+    // Otherwise check the file system
     if (defined(ref)) {
         // TODO: $ref could also be absolute.
         var filename = path.join(basePath, ref);
@@ -33,3 +45,4 @@ function replaceRef(schema, basePath) {
 
     return schema;
 }
+

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -156,3 +156,4 @@ function normalizeRequired(schema) {
 
     return schema;
 }
+


### PR DESCRIPTION
This PR allows locally defined sub-schema references to be resolved. See #8. Also allows looser matching of the $schema field, i.e. allowing a '#' to be added, which is perfectly valid.

+ [ ] Check for id on schema and in map
+ [ ] Allow nested definitions