### PR TITLE
Add support for enum values defined via anyOf

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,9 +1,10 @@
 The following people have contributed to wetzel, under the following agreements:
 
-## [Corporate CLA](http://www.agi.com/licenses/corporate-cla-agi-v1.0.txt)
+## [Corporate CLA](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Documentation/Contributors/CLAs/corporate-cla-agi-v1.0.txt)
 
 * [Analytical Graphics, Inc.](http://www.agi.com/)
    * [Patrick Cozzi](https://github.com/pjcozzi)
 
-## [Individual CLA](http://www.agi.com/licenses/individual-cla-agi-v1.0.txt)
-* [Matthew McMullan](https://github.com/MattMcMullan)
+## [Individual CLA](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Documentation/Contributors/CLAs/individual-cla-agi-v1.0.txt)
+   * [Matthew McMullan](https://github.com/MattMcMullan)
+   * [Howard Wolosky](https://github.com/HowardWolosky)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Options:
 * The `-w` option will suppress any warnings about potential documentation problems that wetzel normally prints by default.
 * The `-d` option lets you specify the root filename that will be used for writing intermediate wetzel artifacts that are useful when doing wetzel development.
 * The `-a` option will attempt to aggressively auto-link referenced type names in descriptions between each other.  If it's too agressive, you can add `=cqo` so that it only attempts to auto-link type names that are within "code-quotes only" (cqo) (e.g.: ``typeName``)
+* The `-i` option lets you specify an array of schema filenames that might be referenced by others, but shouldn't get their own documentation section.
 
 <a name="common-usage"></a>
 ## Common Usage
@@ -109,10 +110,13 @@ wetzel ../glTF/specification/2.0/schema/gltf.schema.json -l 2 -p schema/ -i "['g
 That will generate documentation for glTF.schema.json, as well as all referenced schemas,
 all in a single set of markdown with inter-type linking.  By specifying the `-p` parameter,
 you've indicated where the actual json schema files will live relative to the documentation
-so that the type documentation can directly link to the type json file.  By specifying the
-`-i` parameter, you've specified the list of schema files that should be ignored when writing
-out the top-level types.  By specifying the `-a` parameter, it will aggressively attempt to
-auto-link all referenced type names with each other.
+so that the type documentation can directly link to the type json file. By specifying the
+`-a` parameter, it will aggressively attempt to auto-link all referenced type names with each other.
+
+By specifying the `-i` property and that array of filenames, you are ensuring that there won't
+be a Table of Contents entry for those types, nor will there be individual documentation sections
+for those types (since they only exist to be referenced by other types to make type composition/authoring
+simpler and consistent).
 
 <a name="Limitations"></a>
 ## Limitations

--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -13,6 +13,7 @@ if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
         '  -l,  --headerLevel        Top-level header. Default: 1\n' +
         '  -p,  --schemaPath         The path string that should be used when generating the schema reference paths.\n' +
         '  -a,  --autoLink           Aggressively auto-inter-link types referenced in descriptions.  Add =cqo to auto-link types that are in code-quotes only.\n' +
+        '  -i                        An array of schema filenames (no paths) that should not get their own table of contents entry, nor type listing (they are just used for sharing properties across multiple other schemas)'
         '  -d,  --debug              Provide a path, and this will save out intermediate processing artifacts useful in debugging wetzel.' +
         '  -w,  --suppressWarnings   Will not print out WETZEL_WARNING strings indicating identified conversion problems. Default: false';
     process.stdout.write(help);
@@ -33,6 +34,14 @@ switch (defaultValue(argv.a, argv.autoLink)) {
         break;
 }
 
+// We're expecting users to pass in an array as a "string", but we aren't expecting them
+// to pass it in as a correctly JSON-escaped string.  Therefore, we need to replace single
+// or double-quotes with a backslash-double-quote, and then we can parse the object.
+var ignorableTypesString = defaultValue(argv.i, '[]');
+ignorableTypesString = ignorableTypesString.replace(/'/g, '\"');
+ignorableTypesString = ignorableTypesString.replace(/"/g, '\"');
+var ignorableTypes = JSON.parse(ignorableTypesString);
+
 process.stdout.write(generateMarkdown({
     schema: schema,
     filePath: filepath,
@@ -43,4 +52,5 @@ process.stdout.write(generateMarkdown({
     debug: defaultValue(defaultValue(argv.d, argv.debug), null),
     suppressWarnings: defaultValue(defaultValue(argv.w, argv.suppressWarnings), false),
     autoLink: autoLink,
+    ignorableTypes: ignorableTypes
 }));

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -28,14 +28,14 @@ function generateMarkdown(options) {
     var resolved = null;
     if (defined(schemaRef)) {
         if (schemaRef === 'http://json-schema.org/draft-03/schema') {
-            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.ignorableTypes, options.debug);
         }
         else if (schemaRef === 'http://json-schema.org/draft-04/schema') {
-            resolved = schema4.resolve(schema, options.fileName, options.basePath, options.debug);
+            resolved = schema4.resolve(schema, options.fileName, options.basePath, options.ignorableTypes, options.debug);
         }
         else
         {
-            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.ignorableTypes, options.debug);
             md += '> WETZEL_WARNING: Only JSON Schema 3 or 4 is supported. Treating as Schema 3.\n\n';
         }
     }
@@ -186,8 +186,8 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
     for (var name in properties) {
         if (properties.hasOwnProperty(name)) {
             var property = properties[name];
-            var type = property.type;
             var summary = getPropertySummary(property, knownTypes, autoLink);
+            var type = summary.type;
 
             md += headerMd + ' ' + title + '.' + name + (summary.required === 'Yes' ? style.requiredIcon : '') + '\n\n';
 
@@ -269,9 +269,10 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
 
             var additionalProperties = property.additionalProperties;
             if (defined(additionalProperties) && (typeof additionalProperties === 'object')) {
-                if (defined(additionalProperties.type)) {
+                var additionalPropertiesType = getPropertyType(additionalProperties);
+                if (defined(additionalPropertiesType)) {
                     // TODO: additionalProperties is really a full schema
-                    var formattedType = style.typeValue(additionalProperties.type)
+                    var formattedType = style.typeValue(additionalPropertiesType)
                     if ((additionalProperties.type === 'object') && defined(property.title))
                     {
                         formattedType = style.linkType(property.title, property.title, autoLink);
@@ -296,7 +297,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
 }
 
 function getPropertySummary(property, knownTypes, autoLink) {
-    var type = defaultValue(property.type, 'any');
+    var type = defaultValue(getPropertyType(property), 'any');
     var formattedType = style.typeValue(type);
 
     if (type === 'array') {
@@ -365,10 +366,20 @@ function getPropertySummary(property, knownTypes, autoLink) {
     };
 }
 
+/**
+ * @function getEnumString
+ * Gets the string describing the possible enum values.
+ * Will try getting the information from the enum/gltf_enumNames properties, but if they don't exist,
+ * it will fall back to trying to get the values from the anyOf object.
+ * @param  {object} schema The schema object that may be of an enum type.
+ * @param  {string} type The name of the object type for the enum values (e.g. string, integer, etc..)
+ * @return {string} A string that enumerates all the possible enum values for this schema object.
+ */
 function getEnumString(schema, type) {
     var propertyEnum = schema['enum'];
     if (!defined(propertyEnum)) {
-        return undefined;
+        // It's possible that the enum value is defined using the anyOf construct instead.
+        return getAnyOfEnumString(schema, type);
     }
 
     var propertyEnumNames = schema['gltf_enumNames'];
@@ -376,12 +387,12 @@ function getEnumString(schema, type) {
     var allowedValues = '';
     var length = propertyEnum.length;
     for (var i = 0; i < length; ++i) {
-        var element = propertyEnum[i];
+        var element = style.enumElement(propertyEnum[i], type);
         if (defined(propertyEnumNames)) {
             element += " (" + propertyEnumNames[i] + ")";
         }
 
-        allowedValues += style.enumElement(element, type);
+        allowedValues += element;
         if (i !== length - 1) {
             allowedValues += ', ';
         }
@@ -390,11 +401,88 @@ function getEnumString(schema, type) {
 }
 
 /**
+ * @function getAnyOfEnumString
+ * Gets the string describing the possible enum values, if they are defined within a JSON anyOf object.
+ * @param  {object} schema The schema object that may be of an enum type.
+ * @param  {string} type The name of the object type for the enum values (e.g. string, integer, etc..)
+ * @return {string} A string that enumerates all the possible enum values for this schema object.
+ */
+function getAnyOfEnumString(schema, type) {
+    var propertyAnyOf = schema['anyOf'];
+    if (!defined(propertyAnyOf)) {
+        return undefined;
+    }
+
+    var allowedValues = '';
+    var length = propertyAnyOf.length;
+    for (var i = 0; i < length; ++i) {
+        var element = propertyAnyOf[i];
+        var enumValue = element['enum'];
+        var enumDescription = element['description'];
+
+        // The likely scenario when there's no enum value is that it's the object
+        // containing the _type_ of the enum.  Otherwise, it should be an array with
+        // a single value in it.
+        if (!defined(enumValue) || !Array.isArray(enumValue) || enumValue.length === 0) {
+            continue;
+        }
+
+        var enumString = style.enumElement(enumValue[0], type);
+        if (defined(enumDescription)) {
+            enumString  += " (" + enumDescription + ")";
+        }
+
+        if (allowedValues.length > 0) {
+            allowedValues += ', ';
+        }
+
+        allowedValues += enumString;
+    }
+
+    return allowedValues;
+}
+
+/**
+ * @function getPropertyType
+ * Determines the type of of a property, taking into account that it
+ * might be defined within an anyOf property for enum values.
+ * @param  {object} schema The schema object that may be of an enum type.
+ * @return {string} The type of the enum
+ */
+function getPropertyType(schema) {
+    // For non-anyOf enum types, the type will be a regular property on the object.
+    var type = schema.type;
+    if (defined(type))
+    {
+        return type;
+    }
+
+    // For enums stored using anyOf, we'll need to get it from within anyOf.
+    var propertyAnyOf = schema['anyOf'];
+    if (!defined(propertyAnyOf)) {
+        return undefined;
+    }
+
+    // The type will be defined as one of the objects contained within
+    // the anyOf property, and the only property within that object with
+    // a property name "type" indicating the type of the enum value.
+    var length = propertyAnyOf.length;
+    for (var i = 0; i < length; ++i) {
+        type = propertyAnyOf[i]['type'];;
+        if (defined(type)) {
+            break;
+        }
+    }
+
+    return type;
+}
+
+/**
 * @function autoLinkDescription
 * This will take a string that describes a type that may potentially reference _other_ types, and then
 * automatically add markdown link refences to those other types inline. This is an admittedly simple
 * (and potentially buggy) approach to the problem, but seems sufficient for the needs of glTF.
-* @param  {type} description The string that should be auto-linked
+* @param  {string} description The string that should be auto-linked
 * @param  {string[]} knownTypes  Array of known strings that are types that should be auto-linked if found.
 * If there are multiple types with the same starting root string, it's imperative that the array is sorted such that the longer names are ordered first.
 * @param  {string} autoLink Enum value indicating how the auto-linking should be handled.

--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -6,9 +6,6 @@ var fs = require('fs');
 
 module.exports = replaceRef;
 
-// TODO: allow this to be command-line configurable
-var ignorableTypes = ['gltfid.schema.json', 'gltfchildofrootproperty.schema.json', 'gltfproperty.schema.json'];
-
 /**
 * @function replaceRef
 * Replaces json schema file references referenced with a $ref property
@@ -16,10 +13,11 @@ var ignorableTypes = ['gltfid.schema.json', 'gltfchildofrootproperty.schema.json
 * @todo Does not currently support absolute reference paths, only relative paths.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {object} schemaReferences - An object that will be populated with all schemas referenced by this object
 * @return {object} The schema object with all schema file referenced replaced with the actual file content.
 */
-function replaceRef(schema, basePath, schemaReferences) {
+function replaceRef(schema, basePath, ignorableTypes, schemaReferences) {
     schemaReferences = defaultValue(schemaReferences, {});
 
     var ref = schema.$ref;
@@ -27,17 +25,21 @@ function replaceRef(schema, basePath, schemaReferences) {
         // TODO: $ref could also be absolute.
         var filePath = path.join(basePath, ref);
         var refSchema = JSON.parse(fs.readFileSync(filePath));
+
+        // If a type is supposed to be ignored, that means that its contents should be applied
+        // to the referencing schema, but it shouldn't be called out as a top-level type by itself
+        // (meaning it would never show up in a table of contents or get its own documentation section).
         if (ignorableTypes.indexOf(ref.toLowerCase()) < 0) {
             schemaReferences[refSchema.title] = { schema: refSchema, fileName: ref };
         }
         
-        return replaceRef(refSchema, basePath, schemaReferences);
+        return replaceRef(refSchema, basePath, ignorableTypes, schemaReferences);
     }
 
     for (var name in schema) {
         if (schema.hasOwnProperty(name)) {
             if (typeof schema[name] === 'object') {
-                schema[name] = replaceRef(schema[name], basePath, schemaReferences);
+                schema[name] = replaceRef(schema[name], basePath, ignorableTypes, schemaReferences);
             }
         }
     }

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -16,10 +16,11 @@ module.exports = { resolve: resolve };
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its collection of referenced schemas
 */
-function resolve(schema, fileName, basePath, debugOutputPath) {
+function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -31,7 +32,7 @@ function resolve(schema, fileName, basePath, debugOutputPath) {
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName };
-    schemaClone = replaceRef(schemaClone, basePath, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, basePath, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -16,10 +16,11 @@ module.exports = { resolve: resolve };
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its collection of referenced schemas
 */
-function resolve(schema, fileName, basePath, debugOutputPath) {
+function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -31,7 +32,7 @@ function resolve(schema, fileName, basePath, debugOutputPath) {
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName };
-    schemaClone = replaceRef(schemaClone, basePath, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, basePath, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }


### PR DESCRIPTION
The glTF schema is migrating towards defining enum values
usig the JSON `anyOf` construct.

Whereas before, an enum property might have looked like this:

        "interpolation" : {
            "type" : "string",
            "description" : "Interpolation algorithm.",
            "enum" : ["LINEAR", "STEP"],
            "default" : "LINEAR"
        }

Now it looks like this:

        "interpolation": {
            "description": "Interpolation algorithm.",
            "default": "LINEAR",
            "anyOf": [
                {
                    "enum": [ "LINEAR" ]
                },
                {
                    "enum": [ "STEP" ]
                },
                {
                    "type": "string"
                }
            ]
        }

This updates wetzel to support enums defined both ways.

It also fixes a bug where non-string "default" values (like
boolean or int) were not being rendered correctly because
their length could not be verified to be `> 0`.

Additionally adds true command-line support for ignorable types
which was previously suggested in the README but wasn't actually
implemented.