### PR TITLE
Bullet list for enum values

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ This JSON Schema:
 
 is used to generate this Markdown documentation:
 
-# example
+# Objects
+* [`example`](#reference-example) (root object)
+
+
+---------------------------------------
+<a name="reference-example"></a>
+## example
 
 Example description.
 
@@ -49,21 +55,28 @@ Example description.
 
 Additional properties are not allowed.
 
-## example.byteOffset
+### example.byteOffset
 
 The offset relative to the start of the buffer in bytes.
 
 * **Type**: `integer`
 * **Required**: No, default: `0`
-* **Minimum**:` >= 0`
+* **Minimum**: ` >= 0`
 
-## example.type :white_check_mark:
+### example.type :white_check_mark:
 
 Specifies if the elements are scalars, vectors, or matrices.
 
 * **Type**: `string`
 * **Required**: Yes
-* **Allowed values**: `"SCALAR"`, `"VEC2"`, `"VEC3"`, `"VEC4"`, `"MAT2"`, `"MAT3"`, `"MAT4"`
+* **Allowed values**:
+   * `"SCALAR"`
+   * `"VEC2"`
+   * `"VEC3"`
+   * `"VEC4"`
+   * `"MAT2"`
+   * `"MAT3"`
+   * `"MAT4"`
 
 ---
 
@@ -129,7 +142,7 @@ Pull requests are appreciated.  Please use the same [Contributor License Agreeme
 
 ---
 
-Developed by the Cesium team.
+Developed by the Cesium team and external contributors.
 <p align="center">
 <a href="http://cesiumjs.org/"><img src="doc/cesium.png" /></a>
 </p>

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -393,7 +393,7 @@ function getEnumString(schema, type, depth) {
             element += " " + propertyEnumNames[i];
         }
 
-        allowedValues += style.bulletItem(element.toString(), depth);
+        allowedValues += style.bulletItem(element, depth);
     }
     return allowedValues;
 }
@@ -431,7 +431,7 @@ function getAnyOfEnumString(schema, type, depth) {
             enumString  += " " + enumDescription;
         }
 
-        allowedValues += style.bulletItem(enumString, depth).toString();
+        allowedValues += style.bulletItem(enumString, depth);
     }
 
     return allowedValues;

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -59,7 +59,7 @@ function generateMarkdown(options) {
             orderedTypesDescending,
             options.autoLink);
     }
-    
+
     return md;
 }
 
@@ -92,7 +92,7 @@ function getTableOfContentsMarkdown(schema, orderedTypes, headerLevel) {
 * @param  {int} headerLevel               The starting level for the headers.
 * @param  {boolean} suppressWarnings      Indicates if wetzel warnings should be printed in the documentation.
 * @param  {string} schemaRelativeBasePath The path, relative to where this documentation lives, that the schema files can be found.
-* Leave as null if you don't want the documentation to link to the schema files. 
+* Leave as null if you don't want the documentation to link to the schema files.
 * @param  {object} knownTypes             The dictionary of types and their schema information.
 * @param  {string} autoLink               Enum value indicating how the auto-linking should be handled.
 * @return {string}                        The markdown for the schema.
@@ -231,7 +231,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
                     md += '   * Each element in the array must have length less than or equal to ' + style.minMax(items.maxLength) + '.\n';
                 }
 
-                var itemsString = getEnumString(items, type);
+                var itemsString = getEnumString(items, type, 2);
                 if (defined(itemsString)) {
                     md += '   * Each element in the array must be one of the following values: ' + itemsString + '.\n';
                 }
@@ -262,7 +262,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
                 md += '* ' + style.propertyDetails('Minimum Length') + style.minMax(': >= ' + minLength) + '\n';
             }
 
-            var enumString = getEnumString(property, type);
+            var enumString = getEnumString(property, type, 1);
             if (defined(enumString)) {
                 md += '* ' + style.propertyDetails('Allowed values') + ': ' + enumString + '\n';
             }
@@ -373,29 +373,28 @@ function getPropertySummary(property, knownTypes, autoLink) {
  * it will fall back to trying to get the values from the anyOf object.
  * @param  {object} schema The schema object that may be of an enum type.
  * @param  {string} type The name of the object type for the enum values (e.g. string, integer, etc..)
+ * @param  {integer} depth How deep the bullet points for enum values should be.  Maximum is 2.
  * @return {string} A string that enumerates all the possible enum values for this schema object.
  */
-function getEnumString(schema, type) {
+function getEnumString(schema, type, depth) {
     var propertyEnum = schema['enum'];
     if (!defined(propertyEnum)) {
         // It's possible that the enum value is defined using the anyOf construct instead.
-        return getAnyOfEnumString(schema, type);
+        return getAnyOfEnumString(schema, type, depth);
     }
 
     var propertyEnumNames = schema['gltf_enumNames'];
 
     var allowedValues = '';
+    var prefix = '\n' + ('      '.substring(0, depth * 3)) + '* ';
     var length = propertyEnum.length;
     for (var i = 0; i < length; ++i) {
         var element = style.enumElement(propertyEnum[i], type);
         if (defined(propertyEnumNames)) {
-            element += " (" + propertyEnumNames[i] + ")";
+            element += " " + propertyEnumNames[i];
         }
 
-        allowedValues += element;
-        if (i !== length - 1) {
-            allowedValues += ', ';
-        }
+        allowedValues += prefix + element;
     }
     return allowedValues;
 }
@@ -405,15 +404,17 @@ function getEnumString(schema, type) {
  * Gets the string describing the possible enum values, if they are defined within a JSON anyOf object.
  * @param  {object} schema The schema object that may be of an enum type.
  * @param  {string} type The name of the object type for the enum values (e.g. string, integer, etc..)
+ * @param  {integer} depth How deep the bullet points for enum values should be.  Maximum is 2.
  * @return {string} A string that enumerates all the possible enum values for this schema object.
  */
-function getAnyOfEnumString(schema, type) {
+function getAnyOfEnumString(schema, type, depth) {
     var propertyAnyOf = schema['anyOf'];
     if (!defined(propertyAnyOf)) {
         return undefined;
     }
 
     var allowedValues = '';
+    var prefix = '\n' + ('      '.substring(0, depth * 3)) + '* ';
     var length = propertyAnyOf.length;
     for (var i = 0; i < length; ++i) {
         var element = propertyAnyOf[i];
@@ -429,14 +430,10 @@ function getAnyOfEnumString(schema, type) {
 
         var enumString = style.enumElement(enumValue[0], type);
         if (defined(enumDescription)) {
-            enumString  += " (" + enumDescription + ")";
+            enumString  += " " + enumDescription;
         }
 
-        if (allowedValues.length > 0) {
-            allowedValues += ', ';
-        }
-
-        allowedValues += enumString;
+        allowedValues += prefix + enumString;
     }
 
     return allowedValues;

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -233,7 +233,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
 
                 var itemsString = getEnumString(items, type, 2);
                 if (defined(itemsString)) {
-                    md += '   * Each element in the array must be one of the following values: ' + itemsString + '.\n';
+                    md += '   * Each element in the array must be one of the following values:\n' + itemsString;
                 }
             }
 
@@ -264,7 +264,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
 
             var enumString = getEnumString(property, type, 1);
             if (defined(enumString)) {
-                md += '* ' + style.propertyDetails('Allowed values') + ': ' + enumString + '\n';
+                md += '* ' + style.propertyDetails('Allowed values') + ':\n' + enumString;
             }
 
             var additionalProperties = property.additionalProperties;
@@ -386,7 +386,6 @@ function getEnumString(schema, type, depth) {
     var propertyEnumNames = schema['gltf_enumNames'];
 
     var allowedValues = '';
-    var prefix = '\n' + ('      '.substring(0, depth * 3)) + '* ';
     var length = propertyEnum.length;
     for (var i = 0; i < length; ++i) {
         var element = style.enumElement(propertyEnum[i], type);
@@ -394,7 +393,7 @@ function getEnumString(schema, type, depth) {
             element += " " + propertyEnumNames[i];
         }
 
-        allowedValues += prefix + element;
+        allowedValues += style.bulletItem(element.toString(), depth);
     }
     return allowedValues;
 }
@@ -414,7 +413,6 @@ function getAnyOfEnumString(schema, type, depth) {
     }
 
     var allowedValues = '';
-    var prefix = '\n' + ('      '.substring(0, depth * 3)) + '* ';
     var length = propertyAnyOf.length;
     for (var i = 0; i < length; ++i) {
         var element = propertyAnyOf[i];
@@ -433,7 +431,7 @@ function getAnyOfEnumString(schema, type, depth) {
             enumString  += " " + enumDescription;
         }
 
-        allowedValues += prefix + enumString;
+        allowedValues += style.bulletItem(enumString, depth).toString();
     }
 
     return allowedValues;

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -71,7 +71,6 @@ function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
 * those properties into the referencing part of the schema.
 * @param  {object} derived - The json schema object that may have an 'allOf' property that needs resolving.
 * @return {object} The resolved json schema object.
-* @todo Consider adding support for 'anyOf' and 'oneOf' as well.  These currently aren't used by glTF.
 */
 function resolveInheritance(derived) {
     var base = derived['allOf'];

--- a/lib/style.js
+++ b/lib/style.js
@@ -150,16 +150,7 @@ function getSectionMarkdown(section, level) {
 * @return {string} The markdown string representing the item as a bulleted item at the proper indentation.
 */
 function bulletItem(item, indentationLevel) {
-    var md = '';
-
-    indentationLevel = defaultValue(indentationLevel, 0);
-
-    for (var i = 0; i < indentationLevel; ++i) {
-        md += '   ';
-    }
-
-    md = '* ' + item + '\n';
-    return md;
+    return (' '.repeat(indentationLevel * 3)) + '* ' + item + '\n';
 }
 
 /**

--- a/lib/style.js
+++ b/lib/style.js
@@ -150,6 +150,7 @@ function getSectionMarkdown(section, level) {
 * @return {string} The markdown string representing the item as a bulleted item at the proper indentation.
 */
 function bulletItem(item, indentationLevel) {
+    indentationLevel = defaultValue(indentationLevel, 0);
     return (' '.repeat(indentationLevel * 3)) + '* ' + item + '\n';
 }
 


### PR DESCRIPTION
I think they're easier to read this way.  The example in the README looks more verbose, but enums that have long descriptions per-value are much better.

/cc @HowardWolosky 