### PR TITLE
Add support for null as value of enum

### DIFF
--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -19,6 +19,10 @@ module.exports = replaceRef;
 * @return {object} The schema object with all schema file referenced replaced with the actual file content.
 */
 function replaceRef(schema, basePath, ignorableTypes, schemaReferences, parentTitle) {
+    // According to specification 'null' as type may exist as null in enum
+    if (schema === null) {
+        return {};
+    }
     schemaReferences = defaultValue(schemaReferences, {});
 
     var ref = schema.$ref;


### PR DESCRIPTION
 * Add support for null as value of enum.

Example: 

```javascript
{
  "$schema": "http://json-schema.org/draft-04/schema",
  "id" : "size_type",
  "title" : "Type for size",
  "description" : "Type for size",
  "type" : ["string","null"],
  "enum" : [
    null,
    "regular",
    "petite",
    "plus",
    "big",
    "tall",
    "maternity"
  ]
}
```