### PR TITLE
Add a searchPath parameter such that the tool can reference the base

### DIFF
--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -12,6 +12,7 @@ if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
     var help = 'Usage: node ' + path.basename(__filename) + ' [path-to-json-schema-file] [OPTIONS]\n' +
         '  -l,  --headerLevel        Top-level header. Default: 1\n' +
         '  -p,  --schemaPath         The path string that should be used when generating the schema reference paths.\n' +
+        '  -s,  --searchPath         The path string that should be used when loading the schema reference paths.\n' +
         '  -a,  --autoLink           Aggressively auto-inter-link types referenced in descriptions.\n' +
         '                                Add =cqo to auto-link types that are in code-quotes only.\n' +
         '  -i                        An array of schema filenames (no paths) that should not get their own\n' +
@@ -47,11 +48,16 @@ ignorableTypesString = ignorableTypesString.replace(/'/g, '\"');
 ignorableTypesString = ignorableTypesString.replace(/"/g, '\"');
 var ignorableTypes = JSON.parse(ignorableTypesString);
 
+var searchPath = ['', path.dirname(filepath)];
+if (defined(argv.s) || defined(argv.searchPath)) {
+    searchPath.push(defaultValue(argv.s, argv.searchPath));
+}
+
 process.stdout.write(generateMarkdown({
     schema: schema,
     filePath: filepath,
     fileName: path.basename(filepath),
-    basePath: path.dirname(filepath),
+    searchPath: searchPath,
     headerLevel: defaultValue(defaultValue(argv.l, argv.headerLevel), 1),
     schemaRelativeBasePath: defaultValue(defaultValue(argv.p, argv.schemaPath), null),
     debug: defaultValue(defaultValue(argv.d, argv.debug), null),

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -19,20 +19,20 @@ module.exports = generateMarkdown;
 function generateMarkdown(options) {
     var md = '';
     var schema = options.schema;
-    options.basePath = defaultValue(options.basePath, '');
+    options.searchPath = defaultValue(options.searchPath, ['']);
 
     // Verify JSON Schema version
     var schemaRef = schema.$schema;
     var resolved = null;
     if (defined(schemaRef)) {
         if (schemaRef === 'http://json-schema.org/draft-03/schema') {
-            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.ignorableTypes, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
         }
         else if (schemaRef === 'http://json-schema.org/draft-04/schema') {
-            resolved = schema4.resolve(schema, options.fileName, options.basePath, options.ignorableTypes, options.debug);
+            resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
         }
         else {
-            resolved = schema3.resolve(schema, options.fileName, options.basePath, options.ignorableTypes, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
             md += '> WETZEL_WARNING: Only JSON Schema 3 or 4 is supported. Treating as Schema 3.\n\n';
         }
     }

--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -12,20 +12,30 @@ module.exports = replaceRef;
 * with the actual file content from the referenced schema file.
 * @todo Does not currently support absolute reference paths, only relative paths.
 * @param  {object} schema - The parsed json schema file as an object
-* @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string[]} searchPaths - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {object} schemaReferences - An object that will be populated with all schemas referenced by this object
 * @param  {string} parentTitle - A string that contains the title of the parent object
 * @return {object} The schema object with all schema file referenced replaced with the actual file content.
 */
-function replaceRef(schema, basePath, ignorableTypes, schemaReferences, parentTitle) {
+function replaceRef(schema, searchPaths, ignorableTypes, schemaReferences, parentTitle) {
     schemaReferences = defaultValue(schemaReferences, {});
 
     var ref = schema.$ref;
     if (defined(ref)) {
         // TODO: $ref could also be absolute.
-        var filePath = path.join(basePath, ref);
-        var refSchema = JSON.parse(fs.readFileSync(filePath));
+        var refSchema;
+        for (var searchPath of searchPaths) {
+            try {
+                var filePath = path.join(searchPath, ref);
+                refSchema = JSON.parse(fs.readFileSync(filePath));
+                break;
+            } catch (ex) { refSchema = undefined; }
+        }
+
+        if (refSchema === undefined) {
+            throw new Error(`Unable to find $ref ${ref}`);
+        }
 
         // If a type is supposed to be ignored, that means that its contents should be applied
         // to the referencing schema, but it shouldn't be called out as a top-level type by itself
@@ -49,13 +59,13 @@ function replaceRef(schema, basePath, ignorableTypes, schemaReferences, parentTi
             }
         }
 
-        return replaceRef(refSchema, basePath, ignorableTypes, schemaReferences, schema.title === undefined ? parentTitle : schema.title);
+        return replaceRef(refSchema, searchPaths, ignorableTypes, schemaReferences, schema.title === undefined ? parentTitle : schema.title);
     }
 
     for (var name in schema) {
         if (schema.hasOwnProperty(name)) {
             if (typeof schema[name] === 'object') {
-                schema[name] = replaceRef(schema[name], basePath, ignorableTypes, schemaReferences, schema.title === undefined ? parentTitle : schema.title);
+                schema[name] = replaceRef(schema[name], searchPaths, ignorableTypes, schemaReferences, schema.title === undefined ? parentTitle : schema.title);
             }
         }
     }

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -14,12 +14,12 @@ module.exports = { resolve: resolve };
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
-* @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string[]} searchPath - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its collection of referenced schemas
 */
-function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
+function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -31,7 +31,7 @@ function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, basePath, ignorableTypes, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, searchPath, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -14,12 +14,12 @@ module.exports = { resolve: resolve };
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
-* @param  {string} basePath - The root path where any relative schema file references can be resolved
+* @param  {string[]} searchPath - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its collection of referenced schemas
 */
-function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
+function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -31,7 +31,7 @@ function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, basePath, ignorableTypes, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, searchPath, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }


### PR DESCRIPTION
glTF schema while creating documentation for an extension that is in
some other arbitrary path.