### PR TITLE
Type names and links

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -39,8 +39,8 @@ function generateMarkdown(options) {
 
     schema = resolved.schema;
     var orderedTypes = sortObject(resolved.referencedSchemas);
-    for (let type in orderedTypes) {
-        orderedTypes[type].children.sort();
+    for (let title in orderedTypes) {
+        orderedTypes[title].children.sort();
     }
 
     // We need the reverse-sorted version so that when we do type searching we find the longest type first.
@@ -48,11 +48,11 @@ function generateMarkdown(options) {
 
     md += getTableOfContentsMarkdown(schema, orderedTypes, options.headerLevel);
 
-    for (let type in orderedTypes) {
+    for (let title in orderedTypes) {
         md += '\n\n';
         md += getSchemaMarkdown(
-            orderedTypes[type].schema,
-            orderedTypes[type].fileName,
+            orderedTypes[title].schema,
+            orderedTypes[title].fileName,
             options.headerLevel + 1,
             options.suppressWarnings,
             options.schemaRelativeBasePath,
@@ -69,19 +69,26 @@ function generateMarkdown(options) {
 * @function getTableOfContentsMarkdown
 * Print a table of contents indicating (and linking to) all of the types that are documented
 * @param  {object} schema       The root schema that the documentation is for.
-* @param  {object} orderedTypes The ordered collection of types for the TOC.
+* @param  {object} orderedTypes The types for the TOC, as an ordered map from schema.title to objects
+*                               containing the schema, the file name, parent titles and children titles
 * @param  {int} headerLevel     The level that the header for the TOC should be displayed at.
 * @return {string} The markdown for the table of contents.
 */
 function getTableOfContentsMarkdown(schema, orderedTypes, headerLevel) {
     var md = style.getHeaderMarkdown(headerLevel) + ' Objects\n';
-    for (var type in orderedTypes) {
+    for (var title in orderedTypes) {
         // Regardless of what the user chooses for how types are auto-linked, we'll always
         // link the table-of-contents options.
-        if (type === schema.title || orderedTypes[type].parents.length > 1 || orderedTypes[type].parents.indexOf(schema.title) !== -1) {
-            md += style.bulletItem(style.linkType(style.typeValue(type), type, enums.autoLinkOption.codeQuoteOnly) + (type === schema.title ? ' (root object)' : ''));
-            if (type !== schema.title) {
-                md += getRecursiveTOC(orderedTypes, type, 1);
+        const currentType = orderedTypes[title];
+        if (title === schema.title || currentType.parents.length > 1 || currentType.parents.indexOf(schema.title) !== -1) {
+            var typeName = currentType.schema.typeName;
+            if (!defined(typeName)) {
+                typeName = title.toLowerCase().replace(/ /g, ".");
+            }
+            const item = style.getTOCLink(title, typeName) + (title === schema.title ? ' (root object)' : '');
+            md += style.bulletItem(item);
+            if (title !== schema.title) {
+                md += getRecursiveTOC(orderedTypes, title, 1);
             }
         }
     }
@@ -91,18 +98,25 @@ function getTableOfContentsMarkdown(schema, orderedTypes, headerLevel) {
 /**
 * @function getRecursiveTOC
 * Appends children elements to the table of contents, if and only if the child has a single parent
-* @param  {object} orderedTypes The ordered collection of types for the TOC.
-* @param  {string} parentType   A string that contains the type of the parent object.
-* @param  {int} depth           The number of indentation levels that should be applied.
+* @param  {object} orderedTypes The types for the TOC, as an ordered map from schema.title to objects
+*                               containing the schema, the file name, parent titles and children titles
+* @param  {string} parentTitle    A string that contains the title of the parent object.
+* @param  {int} depth             The number of indentation levels that should be applied.
 * @return {string} The markdown for the table of contents.
 */
-function getRecursiveTOC(orderedTypes, parentType, depth) {
+function getRecursiveTOC(orderedTypes, parentTitle, depth) {
     var md = '';
-    for (var i = 0; i < orderedTypes[parentType].children.length; i++) {
-        var currentType = orderedTypes[parentType].children[i];
-        if (orderedTypes[currentType].parents.length === 1) {
-            md += style.bulletItem(style.getTOCLink(currentType.replace(parentType + " ", ""), currentType), depth);
-            md += getRecursiveTOC(orderedTypes, currentType, depth + 1);
+    for (var i = 0; i < orderedTypes[parentTitle].children.length; i++) {
+        var currentTitle = orderedTypes[parentTitle].children[i];
+        if (orderedTypes[currentTitle].parents.length === 1) {
+            const currentType = orderedTypes[currentTitle];
+            var typeName = currentType.schema.typeName;
+            if (!defined(typeName)) {
+                typeName = currentTitle.toLowerCase().replace(/ /g, ".");
+            }
+            const item = style.getTOCLink(currentTitle.replace(parentTitle + " ", ""), typeName);
+            md += style.bulletItem(item, depth);
+            md += getRecursiveTOC(orderedTypes, currentTitle, depth + 1);
         }
     }
     return md;
@@ -129,8 +143,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
     }
 
     // Render section header
-    var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
-    md += style.getSectionMarkdown(title, headerLevel);
+    md += style.getSectionMarkdown(schema, headerLevel, suppressWarnings);
 
     // Render description
     var value = autoLinkDescription(schema.description, knownTypes, autoLink);
@@ -172,6 +185,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
         }
 
         // Render section for each property
+        var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
         md += createPropertiesDetails(schema, title, headerLevel + 1, knownTypes, autoLink);
     }
 
@@ -218,7 +232,11 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
             var summary = getPropertySummary(property, knownTypes, autoLink);
             var type = summary.type;
 
-            var variableTitle = title.toLowerCase().replace(/ /g, ".");
+            var variableTitle = schema.typeName;
+            if (!defined(variableTitle)) {
+                variableTitle = title.toLowerCase().replace(/ /g, ".");
+            }
+
             md += headerMd + ' ' + variableTitle + '.' + name + (summary.required === 'Yes' ? style.requiredIcon : '') + '\n\n';
 
             // TODO: Add plugin point for custom JSON schema properties like gltf_*
@@ -327,7 +345,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
 
 function getPropertySummary(property, knownTypes, autoLink) {
     var type = defaultValue(getPropertyType(property), 'any');
-    var formattedType = style.typeValue(type);
+    var formattedType = style.linkType(style.typeValue(type), type, autoLink);
 
     if (type === 'array') {
         var insideBrackets = '';
@@ -348,15 +366,15 @@ function getPropertySummary(property, knownTypes, autoLink) {
         var arrayInfo = '[' + insideBrackets + ']';
 
         if (defined(property.items) && defined(property.items.type)) {
-            if ((property.items.type === 'object') && defined(property.items.title)) {
-                type = property.items.title;
-                formattedType = style.linkType(type, type, autoLink) + ' ';
+            if ((property.items.type === 'object')) {
+                type = getPropertyType(property.items);
+                formattedType = style.linkType(style.typeValue(type), type, autoLink) + ' ';
 
                 type += arrayInfo;
                 formattedType += style.typeValue(arrayInfo);
             } else {
                 type = property.items.type;
-                formattedType = style.typeValue(type) + ' ';
+                formattedType = style.linkType(style.typeValue(type), type, autoLink) + ' ';
 
                 type += arrayInfo;
                 formattedType += style.typeValue(arrayInfo);
@@ -477,6 +495,14 @@ function getAnyOfEnumString(schema, type, depth) {
  * @return {string} The type of the enum
  */
 function getPropertyType(schema) {
+
+    // If the type name was inserted in the schema based on a $ref,
+    // then this type name will be returned
+    var typeName = schema.typeName;
+    if (defined(typeName)) {
+        return typeName;
+    }
+
     // For non-anyOf enum types, the type will be a regular property on the object.
     var type = schema.type;
     if (defined(type)) {

--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -47,6 +47,15 @@ function replaceRef(schema, basePath, ignorableTypes, schemaReferences, parentTi
             else {
                 schemaReferences[parentTitle] = { schema: undefined, fileName: undefined, parents: [], children: [refSchema.title] };
             }
+
+            // From a reference named "simpleExample.type.schema.json",
+            // extract the "simpleExample.type" part as the type name
+            var typeName = ref;
+            var indexOfFileExtension = ref.indexOf(".schema.json");
+            if (indexOfFileExtension !== -1) {
+                typeName = ref.slice(0, indexOfFileExtension);
+            }
+            refSchema.typeName = typeName;
         }
 
         return replaceRef(refSchema, basePath, ignorableTypes, schemaReferences, schema.title === undefined ? parentTitle : schema.title);

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -17,7 +17,8 @@ module.exports = { resolve: resolve };
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
-* @return {object} The resolved schema object and its collection of referenced schemas
+* @return {object} The resolved schema object and its referenced schemas, as a map from the schema.title to objects
+* that contain the schema, the file name, the parents titles and the children titles
 */
 function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
@@ -46,9 +47,9 @@ function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     }
 
     // Need to process all of the individual referenced schemas as well so that they're ready for conversion.
-    for (var type in referencedSchemas) {
-        if (referencedSchemas[type].schema !== undefined) {
-            extend(referencedSchemas[type].schema);
+    for (var title in referencedSchemas) {
+        if (referencedSchemas[title].schema !== undefined) {
+            extend(referencedSchemas[title].schema);
         }
     }
 

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -17,7 +17,8 @@ module.exports = { resolve: resolve };
 * @param  {string} basePath - The root path where any relative schema file references can be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
-* @return {object} The resolved schema object and its collection of referenced schemas
+* @return {object} The resolved schema object and its referenced schemas, as a map from the schema.title to objects
+* that contain the schema, the file name, the parents titles and the children titles
 */
 function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
@@ -53,10 +54,10 @@ function resolve(schema, fileName, basePath, ignorableTypes, debugOutputPath) {
     }
 
     // Need to process all of the individual referenced schemas as well so that they're ready for conversion.
-    for (var type in referencedSchemas) {
-        if (referencedSchemas[type].schema !== undefined) {
-            resolveInheritance(referencedSchemas[type].schema);
-            normalizeRequired(referencedSchemas[type].schema);
+    for (var title in referencedSchemas) {
+        if (referencedSchemas[title].schema !== undefined) {
+            resolveInheritance(referencedSchemas[title].schema);
+            normalizeRequired(referencedSchemas[title].schema);
         }
     }
 

--- a/lib/style.js
+++ b/lib/style.js
@@ -132,16 +132,24 @@ function getHeaderMarkdown(level) {
 /**
 * @function getSectionMarkdown
 * Gets the markdown syntax for the start of a section.
-* @param  {string} section - The name of the section
+* @param  {object} schema - The schema for which this section is created
 * @param  {int} level - The header lever that is being requested
+* @param  {boolean} suppressWarnings Indicates if wetzel warnings should be printed in the documentation.
 * @return {string} The markdown string that should be placed as the start of the section
 */
-function getSectionMarkdown(section, level) {
+function getSectionMarkdown(schema, level, suppressWarnings) {
     var md = '';
 
     md += '---------------------------------------\n';
-    md += '<a name="' + REFERENCE + section.toLowerCase().replace(/ /g, '-') + '"></a>\n';
-    md += getHeaderMarkdown(level) + ' ' + section + '\n\n';
+
+    var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
+    var typeName = schema.typeName;
+    if (!defined(typeName)) {
+        typeName = title.toLowerCase().replace(/ /g, ".");
+    }
+
+    md += '<a name="' + REFERENCE + createAnchorName(typeName) + '"></a>\n';
+    md += getHeaderMarkdown(level) + ' ' + title + '\n\n';
 
     return md;
 }
@@ -226,6 +234,20 @@ function styleCodeType(string, type) {
 }
 
 /**
+ * Convert the given string into the string that will be used for
+ * the anchors that serve as link targets in the resulting MD. 
+ * 
+ * @param {string} string The string
+ * @return {string} The anchor name
+ */
+function createAnchorName(string) {
+    return string.toLowerCase()
+        .replace(/ /g, "-")
+        .replace(/\./g, "-");
+    return anchorName;
+}
+
+/**
 * @function linkType
 * Finds any occurrence of type in the provided string, and adds a markdown link to it.
 * @param  {string} string - The string that might be referencing a type
@@ -241,7 +263,12 @@ function linkType(string, type, autoLink) {
     } else if ((!defined(type) || type.length === 0)) {
         return string;
     }
-    var typeLink = '#' + REFERENCE + type.toLowerCase().replace(/ /g, '-');
+    if (type === 'integer' || type === 'string' ||
+        type === 'object'  || type === 'number' ||
+        type === 'boolean') {
+        return string;
+    }
+    var typeLink = '#' + REFERENCE + createAnchorName(type);
 
     if (autoLink === enums.autoLinkOption.aggressive) {
         let regExp = new RegExp('([^`\.]|^)' + type + '([ \.]|$)');
@@ -263,6 +290,6 @@ function getTOCLink(displayString, type) {
     } else if ((!defined(type) || type.length === 0)) {
         return displayString;
     }
-    var typeLink = '#' + REFERENCE + type.toLowerCase().replace(/ /g, '-');
+    var typeLink = '#' + REFERENCE + createAnchorName(type);
     return getLinkMarkdown(styleCode(displayString), typeLink);
 }


### PR DESCRIPTION
An update that mainly addresses https://github.com/KhronosGroup/glTF/issues/1013 

**Important notes:**

As mentioned in the comment at https://github.com/KhronosGroup/glTF/issues/1013#issuecomment-388417608 , the output now has some considerable difference to what is currently contained in the spec (https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#objects). This is *not* only due to these changes in wetzel, but also (or maybe mainly) because there have been changes in the *schema*. Most importantly: The `title` attribute in the schema originally had been some (ambiguous) "type name", but became something that is supposed to be a human-readable title in https://github.com/KhronosGroup/glTF/commit/113a75b74442b0061a062ea30bf3fe66c2ee0c87

The most critical point here is that the *anchors* inside the spec page have changed. It will likely be necessary to update the other READMEs, and most of the links that are contained in the Tutorial.

This PR should therefore be merged **if and only if** someone can be reasonably sure that there will likely be no changes to the way how anchors are generated in the near future. Otherwise, we'll have to update a large number of links again. People will not be happy about that.

However, the result of running wetzel as of this PR on the latest glTF schema is shown here: https://github.com/javagl/glTF/tree/reference_links_update/specification/2.0#objects


